### PR TITLE
added check_error to atsit5

### DIFF
--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -681,3 +681,23 @@ end
 @inline function DiffEqBase.set_t!(integrator::SimpleATsit5Integrator, t::Real)
     reinit!(integrator; t0 = t)
 end
+
+#######################################################################################
+# chech_error
+#######################################################################################
+
+function check_error(integrator::SimpleATsit5Integrator)
+	# This implementation is intended to be used for SimpleDiffEq.SimpleATsit5Integrator
+	   if isnan(integrator.dt)
+	       @warn("NaN dt detected. Likely a NaN value in the state, parameters, or derivative value caused this outcome.")
+	       return :DtNaN
+	   end
+
+	   if DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK(integrator.dt, integrator.u, integrator.p, integrator.t)
+	       @warn("Instability detected. Aborting")
+	       return :Unstable
+	   end
+
+	   return :Success
+end
+


### PR DESCRIPTION
The `check_error` for `DEIntegrator` doesn't work for the simple integrator types because they have different fields. I've added a simple function to handle atsit5 which is the default solver in DynamicalSystems.
See: [Issue 184](https://github.com/JuliaDynamics/DynamicalSystems.jl/issues/184) at JuliaDynamics/DynamicalSystems.jl