### PR TITLE
Fix save_everystep = false use case

### DIFF
--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -99,8 +99,8 @@ function DiffEqBase.__solve(prob::ODEProblem, alg::SimpleATsit5;
     end
 
     if saveat === nothing && !save_everystep
-        push!(us, recursivecopy(u))
-        push!(ts, t)
+        push!(us, recursivecopy(integ.u))
+        push!(ts, integ.t)
     end
 
     sol = DiffEqBase.build_solution(prob, alg, ts, us,

--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -86,8 +86,7 @@ function DiffEqBase.__solve(prob::ODEProblem, alg::SimpleATsit5;
         if saveat === nothing && save_everystep
             push!(us, recursivecopy(integ.u))
             push!(ts, integ.t)
-        else
-            saveat !== nothing
+        elseif saveat !== nothing
             while cur_t <= length(ts) && ts[cur_t] <= integ.t
                 if !isinplace(prob)
                     us[cur_t] = integ(ts[cur_t])

--- a/src/tsit5/gpuatsit5.jl
+++ b/src/tsit5/gpuatsit5.jl
@@ -159,8 +159,7 @@ SciMLBase.isadaptive(alg::GPUSimpleATsit5) = true
                 if saveat === nothing && save_everystep
                     push!(us, recursivecopy(u))
                     push!(ts, t)
-                else
-                    saveat !== nothing
+                elseif saveat !== nothing
                     while cur_t <= length(ts) && ts[cur_t] <= t
                         savet = ts[cur_t]
                         θ = (savet - told) / dtold

--- a/test/gpusimpleatsit5_tests.jl
+++ b/test/gpusimpleatsit5_tests.jl
@@ -27,9 +27,14 @@ dt = 1e-2
 odeoop = ODEProblem{false}(loop, SVector{3}(u0), (0.0, 100.0), [10, 28, 8 / 3])
 sol = solve(odeoop, SimpleATsit5(), dt = dt)
 sol2 = solve(odeoop, GPUSimpleATsit5(), dt = dt, abstol = 1e-6, reltol = 1e-3)
+sol3 = solve(odeoop, GPUSimpleATsit5(), dt = dt, abstol = 1e-6, reltol = 1e-3,
+             save_everystep = false)
 
 @test sol.u[5] ≈ sol2.u[5]
 @test sol.t[5] ≈ sol2.t[5]
+
+@test sol.t[end] ≈ sol3.t[end]
+@test sol2.t[end] ≈ sol3.t[end]
 
 sol = solve(odeoop, Tsit5(), dt = dt, saveat = 0.0:0.1:100.0)
 sol2 = solve(odeoop, GPUSimpleATsit5(), dt = dt, saveat = 0.0:0.1:100.0, abstol = 1e-6,
@@ -47,3 +52,16 @@ sol2 = solve(odeoop, GPUSimpleTsit5(), dt = dt)
 
 @test sol.u ≈ sol2.u
 @test sol.t ≈ sol2.t
+
+#=
+Solution seems to be sensitive at 100s,
+hence changing the final tspan to test with save_everystep = false
+=#
+odeoop = remake(odeoop; tspan = (0.0, 10.0))
+
+sol = solve(odeoop, Tsit5(), reltol = 1e-9, abstol = 1e-9, save_everystep = false)
+sol1 = solve(odeoop, GPUSimpleATsit5(), reltol = 1e-9, abstol = 1e-9,
+             save_everystep = false)
+
+@test sol.u≈sol1.u atol=1e-5
+@test sol.t ≈ sol1.t

--- a/test/simpleatsit5_tests.jl
+++ b/test/simpleatsit5_tests.jl
@@ -221,3 +221,23 @@ for k in 1:200
 end
 
 @test length(unique(round.(v; digits = 3))) == 2
+
+#=
+Solution seems to be sensitive at 100s,
+hence changing the final tspan to test with save_everystep = false
+=#
+
+odeiip = remake(odeiip; tspan = (0.0, 10.0))
+odeoop = remake(odeoop; tspan = (0.0, 10.0))
+
+sol = solve(odeiip, Tsit5(), reltol = 1e-9, abstol = 1e-9, save_everystep = false)
+sol1 = solve(odeiip, SimpleATsit5(), reltol = 1e-9, abstol = 1e-9, save_everystep = false)
+
+@test sol.u≈sol1.u atol=1e-5
+@test sol.t ≈ sol1.t
+
+sol = solve(odeoop, Tsit5(), reltol = 1e-9, abstol = 1e-9, save_everystep = false)
+sol1 = solve(odeoop, SimpleATsit5(), reltol = 1e-9, abstol = 1e-9, save_everystep = false)
+
+@test sol.u≈sol1.u atol=1e-5
+@test sol.t ≈ sol1.t


### PR DESCRIPTION
MWE:

```
using SimpleDiffEq
f(u,p,t) = 1.01*u
u0=1/2
tspan = (0.0,1.0)
prob = ODEProblem(f,u0,tspan)
sol = solve(prob,GPUSimpleATsit5(),save_everystep = false)
```
Before:
```
julia> sol = solve(prob,GPUSimpleATsit5(),save_everystep = false)
ERROR: UndefVarError: cur_t not defined
Stacktrace:
 [1] solve(prob::ODEProblem{Float64, Tuple{Float64, Float64}, false, SciMLBase.NullParameters, ODEFunction{false, typeof(f), LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, alg::GPUSimpleATsit5; dt::Float32, saveat::Nothing, save_everystep::Bool, abstol::Float32, reltol::Float32)
   @ SimpleDiffEq ~/.julia/packages/SimpleDiffEq/vIpeG/src/tsit5/gpuatsit5.jl:156
 [2] top-level scope
   @ REPL[6]:1

```

After:

```
julia> sol = solve(prob,GPUSimpleATsit5(),save_everystep = false)
retcode: Default
Interpolation: 1st order linear
t: 2-element Vector{Float32}:
 0.0
 1.0
u: 2-element Vector{Float64}:
 0.5
 1.3728004413314139
```