### PR TITLE
Fix type instability in Tsit5 when using saveat

### DIFF
--- a/src/tsit5/gpuatsit5.jl
+++ b/src/tsit5/gpuatsit5.jl
@@ -6,6 +6,18 @@
 struct GPUSimpleTsit5 <: AbstractSimpleDiffEqODEAlgorithm end
 export GPUSimpleTsit5
 
+function build_adaptive_tsit5_controller_cache(::Type{T}) where {T}
+    beta1 = T(7 / 50)
+    beta2 = T(2 / 25)
+    qmax = T(10.0)
+    qmin = T(1 / 5)
+    gamma = T(9 / 10)
+    qoldinit = T(1e-4)
+    qold = qoldinit
+
+    return beta1, beta2, qmax, qmin, gamma, qoldinit, qold
+end
+
 @muladd function DiffEqBase.solve(prob::ODEProblem,
                                   alg::GPUSimpleTsit5; saveat = nothing,
                                   save_everystep = true,
@@ -110,6 +122,7 @@ SciMLBase.isadaptive(alg::GPUSimpleATsit5) = true
     tspan = prob.tspan
     f = prob.f
     p = prob.p
+    beta1, beta2, qmax, qmin, gamma, qoldinit, _ = build_adaptive_tsit5_controller_cache(eltype(u0))
 
     t = tspan[1]
     tf = prob.tspan[2]


### PR DESCRIPTION
MWE:
```
using SimpleDiffEq, OrdinaryDiffEq

function lorenz(u, p, t)
    σ = p[1]
    ρ = p[2]
    β = p[3]
    du1 = σ * (u[2] - u[1])
    du2 = u[1] * (ρ - u[3]) - u[2]
    du3 = u[1] * u[2] - β * u[3]
    return SVector{3}(du1, du2, du3)
end

u0 = @SVector [1.0f0; 0.0f0; 0.0f0]
tspan = (0.0f0, 10.0f0)
p = @SVector [10.0f0, 28.0f0, 8 / 3.0f0]
prob = ODEProblem{false}(lorenz, u0, tspan, p)
saveat = 0.f0:0.1f0:10.f0

sol = solve(prob, GPUSimpleATsit5(), dt = 0.1f0, saveat = saveat)
```
Before:
```
julia> sol = solve(prob, GPUSimpleATsit5(), dt = 0.1f0, saveat = saveat)
ERROR: MethodError: no method matching bθs(::SVector{22, Float32}, ::Float64)
Closest candidates are:
  bθs(::SVector{22, T}, ::T) where T at ~/.julia/dev/SimpleDiffEq/src/tsit5/tsit5.jl:266
Stacktrace:
 [1] solve(prob::ODEProblem{SVector{3, Float32}, Tuple{Float32, Float32}, false, SVector{3, Float32}, ODEFunction{false, SciMLBase.AutoSpecialize, typeof(lorenz), UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing, Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, alg::GPUSimpleATsit5; dt::Float32, saveat::StepRangeLen{Float32, Float64, Float64, Int64}, save_everystep::Bool, abstol::Float32, reltol::Float32)
   @ SimpleDiffEq ~/.julia/dev/SimpleDiffEq/src/tsit5/gpuatsit5.jl:199
 [2] top-level scope
   @ REPL[33]:1
 [3] top-level scope
   @ ~/.julia/packages/CUDA/DfvRa/src/initialization.jl:52
```
After:
Successfully solves.