### PR TITLE
Fix BigFloat compatibility in MVector size parameter

### DIFF
--- a/src/euler/gpueuler.jl
+++ b/src/euler/gpueuler.jl
@@ -17,7 +17,7 @@ export GPUSimpleEuler
     t = tspan[1]
     tf = prob.tspan[2]
     ts = tspan[1]:dt:tspan[2]
-    us = MVector{length(ts), typeof(u0)}(undef)
+    us = MVector{Int(length(ts)), typeof(u0)}(undef)
     us[1] = u0
     u = u0
 

--- a/src/rk4/gpurk4.jl
+++ b/src/rk4/gpurk4.jl
@@ -17,7 +17,7 @@ export GPUSimpleRK4
     t = tspan[1]
     tf = prob.tspan[2]
     ts = tspan[1]:dt:tspan[2]
-    us = MVector{length(ts), typeof(u0)}(undef)
+    us = MVector{Int(length(ts)), typeof(u0)}(undef)
     us[1] = u0
     u = u0
     half = convert(eltype(u0), 1 // 2)

--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -71,7 +71,7 @@ function DiffEqBase.__solve(prob::ODEProblem, alg::SimpleATsit5;
     else
         ts = saveat
         cur_t = 1
-        us = MVector{length(ts), typeof(u0)}(undef)
+        us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
             us[1] = u0

--- a/src/tsit5/gpuatsit5.jl
+++ b/src/tsit5/gpuatsit5.jl
@@ -26,7 +26,7 @@ export GPUSimpleTsit5
     else
         ts = saveat
         cur_t = 1
-        us = MVector{length(ts), typeof(u0)}(undef)
+        us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
             us[1] = u0
@@ -125,7 +125,7 @@ SciMLBase.isadaptive(alg::GPUSimpleATsit5) = true
     else
         ts = saveat
         cur_t = 1
-        us = MVector{length(ts), typeof(u0)}(undef)
+        us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
             us[1] = u0

--- a/src/verner/gpuvern7.jl
+++ b/src/verner/gpuvern7.jl
@@ -26,7 +26,7 @@ export GPUSimpleVern7
     else
         ts = saveat
         cur_t = 1
-        us = MVector{length(ts), typeof(u0)}(undef)
+        us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
             us[1] = u0
@@ -195,7 +195,7 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern7) = true
     else
         ts = saveat
         cur_t = 1
-        us = MVector{length(ts), typeof(u0)}(undef)
+        us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
             us[1] = u0

--- a/src/verner/gpuvern9.jl
+++ b/src/verner/gpuvern9.jl
@@ -26,7 +26,7 @@ export GPUSimpleVern9
     else
         ts = saveat
         cur_t = 1
-        us = MVector{length(ts), typeof(u0)}(undef)
+        us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
             us[1] = u0
@@ -280,7 +280,7 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern9) = true
     else
         ts = saveat
         cur_t = 1
-        us = MVector{length(ts), typeof(u0)}(undef)
+        us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
             us[1] = u0

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -1,0 +1,86 @@
+using SimpleDiffEq, StaticArrays, Test
+
+# Test interface compatibility with different number types
+
+function decay(u, p, t)
+    return -u
+end
+
+function decay!(du, u, p, t)
+    du .= -u
+    return nothing
+end
+
+@testset "BigFloat scalar support" begin
+    u0 = BigFloat(1.0)
+    tspan = (BigFloat(0.0), BigFloat(1.0))
+    dt = BigFloat(0.01)
+    prob = ODEProblem{false}(decay, u0, tspan, nothing)
+
+    sol = solve(prob, SimpleEuler(), dt = dt)
+    @test eltype(sol.u) == BigFloat
+
+    sol = solve(prob, SimpleRK4(), dt = dt)
+    @test eltype(sol.u) == BigFloat
+
+    sol = solve(prob, SimpleTsit5(), dt = dt)
+    @test eltype(sol.u) == BigFloat
+
+    sol = solve(prob, SimpleATsit5(), dt = dt)
+    @test eltype(sol.u) == BigFloat
+end
+
+@testset "BigFloat Vector support (OOP)" begin
+    u0 = BigFloat[1.0, 2.0, 3.0]
+    tspan = (BigFloat(0.0), BigFloat(1.0))
+    dt = BigFloat(0.01)
+    prob = ODEProblem{false}(decay, u0, tspan, nothing)
+
+    sol = solve(prob, SimpleEuler(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+
+    sol = solve(prob, SimpleRK4(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+
+    sol = solve(prob, SimpleTsit5(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+end
+
+@testset "BigFloat Vector support (IIP)" begin
+    u0 = BigFloat[1.0, 2.0, 3.0]
+    tspan = (BigFloat(0.0), BigFloat(1.0))
+    dt = BigFloat(0.01)
+    prob = ODEProblem{true}(decay!, u0, tspan, nothing)
+
+    sol = solve(prob, SimpleEuler(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+
+    sol = solve(prob, SimpleRK4(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+
+    sol = solve(prob, SimpleTsit5(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+end
+
+@testset "SVector{BigFloat} support" begin
+    u0 = SVector{3, BigFloat}(BigFloat(1.0), BigFloat(2.0), BigFloat(3.0))
+    tspan = (BigFloat(0.0), BigFloat(1.0))
+    dt = BigFloat(0.01)
+    prob = ODEProblem{false}(decay, u0, tspan, nothing)
+
+    sol = solve(prob, SimpleEuler(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+
+    sol = solve(prob, SimpleRK4(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+
+    sol = solve(prob, SimpleTsit5(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+
+    # GPU-style solvers with SVector{BigFloat}
+    sol = solve(prob, GPUSimpleTsit5(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+
+    sol = solve(prob, GPUSimpleATsit5(), dt = dt)
+    @test eltype(sol.u[end]) == BigFloat
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,5 @@ using SimpleDiffEq, SafeTestsets, Test
     @time @safetestset "SimpleRK4 Tests" include("simplerk4_tests.jl")
     @time @safetestset "SimpleEuler Tests" include("simpleeuler_tests.jl")
     @time @safetestset "GPU Compatible ODE Tests" include("gpu_ode_regression.jl")
+    @time @safetestset "Interface Tests" include("interface_tests.jl")
 end


### PR DESCRIPTION
## Summary

- Fixed interface issue where GPU-style solvers fail with BigFloat time values
- When `dt` is a BigFloat, `length(tspan[1]:dt:tspan[2])` returns a BigInt, but `MVector{N,...}` requires `N` to be an Int64
- Added `Int(length(ts))` conversion in 6 GPU solver files
- Added comprehensive interface tests for BigFloat compatibility

## Interface Testing Performed

### JLArrays (GPU-like arrays)
- SimpleEuler, SimpleRK4, SimpleTsit5: ✓ Work with JLArrays (out-of-place mode)
- GPU solvers designed for StaticArrays, not general arrays

### BigFloat
- Scalar: ✓ Works with all solvers
- Vector (OOP): ✓ Works with SimpleEuler, SimpleRK4, SimpleTsit5
- Vector (IIP): ✓ Works with SimpleEuler, SimpleRK4, SimpleTsit5
- SVector{BigFloat}: ✓ Works with all standard solvers + GPUSimpleTsit5, GPUSimpleATsit5
- GPUSimpleRK4 with SVector{BigFloat}: Limited by StaticArrays (MVector doesn't support non-isbits types)

### ArrayInterface.jl
- Verified compatibility with `can_setindex`, `fast_scalar_indexing`, and `restructure` functions

## Test plan

- [x] All existing tests pass
- [x] New interface tests pass (`test/interface_tests.jl`)
- [x] Verified BigFloat solvers work correctly

## Minor notes (not addressed)

Two minor issues were identified but not fixed as they don't cause failures:
1. `qold::Float64`, `abstol::Float64`, `reltol::Float64` in `SimpleATsit5Integrator` could be type-parameterized
2. Hardcoded `1e-14` threshold could use `eps(T)` pattern for different precisions

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)