### PR TITLE
Bump DiffEqBase to v7, SciMLBase to v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,11 +13,11 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-DiffEqBase = "6.122"
+DiffEqBase = "6.122, 7"
 ExplicitImports = "1.14.0"
 JLArrays = "0.1, 0.2, 0.3"
 MuladdMacro = "0.2"
-OrdinaryDiffEq = "6"
+OrdinaryDiffEq = "6, 7"
 Parameters = "0.12"
 RecursiveArrayTools = "2, 3, 4"
 Reexport = "0.2, 1.0"

--- a/src/SimpleDiffEq.jl
+++ b/src/SimpleDiffEq.jl
@@ -5,13 +5,29 @@ module SimpleDiffEq
     using Reexport: @reexport
     using MuladdMacro: @muladd
     @reexport using DiffEqBase: DiffEqBase, ODEProblem, SDEProblem, DiscreteProblem,
-        isinplace, reinit!, u_modified!, ODE_DEFAULT_NORM,
-        set_t!, solve, step!, init, DESolution, @..,
+        isinplace, reinit!, ODE_DEFAULT_NORM,
+        set_t!, solve, step!, init, @..,
         AbstractODEIntegrator, DEIntegrator, ConstantInterpolation,
         __init, __solve, build_solution, has_analytic,
         calculate_solution_errors!, is_diagonal_noise,
         AbstractSDEAlgorithm, AbstractODEAlgorithm, isdiscrete, SciMLBase
     import DiffEqBase.SciMLBase: allows_arbitrary_number_types, allowscomplex, isautodifferentiable, isadaptive
+    # `derivative_discontinuity!` was introduced in DiffEqBase v7 / SciMLBase v3,
+    # replacing the older `u_modified!`. Support both branches so the package can
+    # be used with either DiffEqBase v6 or v7.
+    @static if isdefined(DiffEqBase, :derivative_discontinuity!)
+        using DiffEqBase: derivative_discontinuity!
+        export derivative_discontinuity!
+    else
+        const derivative_discontinuity! = DiffEqBase.u_modified!
+        export derivative_discontinuity!
+    end
+    # Keep `u_modified!` re-exported for backwards compatibility with any user
+    # code that still calls it.
+    @static if isdefined(DiffEqBase, :u_modified!)
+        using DiffEqBase: u_modified!
+        export u_modified!
+    end
     using StaticArrays: SArray, SVector, MVector
     using RecursiveArrayTools: recursivecopy!
     using LinearAlgebra: mul!

--- a/src/euler/euler.jl
+++ b/src/euler/euler.jl
@@ -73,7 +73,7 @@ DiffEqBase.isinplace(::SEI{IIP}) where {IIP} = IIP
 
 function DiffEqBase.__init(
         prob::ODEProblem, alg::SimpleEuler;
-        dt = error("dt is required for this algorithm")
+        dt = error("dt is required for this algorithm"), kwargs...
     )
     return simpleeuler_init(
         prob.f,
@@ -87,7 +87,7 @@ end
 
 function DiffEqBase.__solve(
         prob::ODEProblem, alg::SimpleEuler;
-        dt = error("dt is required for this algorithm")
+        dt = error("dt is required for this algorithm"), kwargs...
     )
     u0 = prob.u0
     tspan = prob.tspan

--- a/src/euler/gpueuler.jl
+++ b/src/euler/gpueuler.jl
@@ -47,7 +47,8 @@ export GPUSimpleEuler
 @muladd function DiffEqBase.solve(
         prob::ODEProblem,
         alg::GPUSimpleEuler;
-        dt = error("dt is required for this algorithm")
+        dt = error("dt is required for this algorithm"),
+        kwargs...
     )
     @assert !isinplace(prob)
     u0 = prob.u0

--- a/src/euler_maruyama.jl
+++ b/src/euler_maruyama.jl
@@ -37,7 +37,8 @@ export SimpleEM
 @muladd function DiffEqBase.solve(
         prob::SDEProblem{uType, tType, false}, alg::SimpleEM,
         args...;
-        dt = error("dt required for SimpleEM")
+        dt = error("dt required for SimpleEM"),
+        kwargs...
     ) where {
         uType,
         tType,
@@ -84,7 +85,8 @@ end
 @muladd function DiffEqBase.solve(
         prob::SDEProblem{uType, tType, true}, alg::SimpleEM,
         args...;
-        dt = error("dt required for SimpleEM")
+        dt = error("dt required for SimpleEM"),
+        kwargs...
     ) where {
         uType,
         tType,

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -40,7 +40,7 @@ SciMLBase.isdiscrete(alg::SimpleFunctionMap) = true
 function DiffEqBase.__solve(
         prob::DiffEqBase.DiscreteProblem{uType, tupType, false},
         alg::SimpleFunctionMap;
-        calculate_values = true
+        calculate_values = true, kwargs...
     ) where {uType, tupType}
     tType = eltype(tupType)
     tspan = prob.tspan
@@ -68,7 +68,7 @@ end
 function DiffEqBase.__solve(
         prob::DiscreteProblem{uType, tupType, true},
         alg::SimpleFunctionMap;
-        calculate_values = true
+        calculate_values = true, kwargs...
     ) where {uType, tupType}
     tType = eltype(tupType)
     tspan = prob.tspan
@@ -110,7 +110,8 @@ end
 
 function DiffEqBase.__init(
         prob::DiscreteProblem,
-        alg::SimpleFunctionMap
+        alg::SimpleFunctionMap;
+        kwargs...
     )
     sol = DiffEqBase.__solve(prob, alg; calculate_values = false)
     F = typeof(prob.f)

--- a/src/rk4/gpurk4.jl
+++ b/src/rk4/gpurk4.jl
@@ -47,7 +47,8 @@ export GPUSimpleRK4
 @muladd function DiffEqBase.solve(
         prob::ODEProblem,
         alg::GPUSimpleRK4;
-        dt = error("dt is required for this algorithm")
+        dt = error("dt is required for this algorithm"),
+        kwargs...
     )
     @assert !isinplace(prob)
     u0 = prob.u0

--- a/src/rk4/rk4.jl
+++ b/src/rk4/rk4.jl
@@ -78,7 +78,7 @@ DiffEqBase.isinplace(::SRK4{IIP}) where {IIP} = IIP
 
 function DiffEqBase.__init(
         prob::ODEProblem, alg::SimpleRK4;
-        dt = error("dt is required for this algorithm")
+        dt = error("dt is required for this algorithm"), kwargs...
     )
     return simplerk4_init(
         prob.f,
@@ -92,7 +92,7 @@ end
 
 function DiffEqBase.__solve(
         prob::ODEProblem, alg::SimpleRK4;
-        dt = error("dt is required for this algorithm")
+        dt = error("dt is required for this algorithm"), kwargs...
     )
     u0 = prob.u0
     tspan = prob.tspan

--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -86,7 +86,14 @@ end
 const SAT5I = SimpleATsit5Integrator
 
 DiffEqBase.isinplace(::SAT5I{IIP}) where {IIP} = IIP
-DiffEqBase.u_modified!(i::SAT5I, bool) = (i.u_modified = bool)
+# Extend the integrator-interface hook on whichever name the installed
+# DiffEqBase provides. DiffEqBase v7+ uses `derivative_discontinuity!`;
+# v6 used `u_modified!`.
+@static if isdefined(DiffEqBase, :derivative_discontinuity!)
+    DiffEqBase.derivative_discontinuity!(i::SAT5I, bool) = (i.u_modified = bool)
+else
+    DiffEqBase.u_modified!(i::SAT5I, bool) = (i.u_modified = bool)
+end
 
 #######################################################################################
 # Initialization
@@ -108,7 +115,7 @@ function DiffEqBase.__solve(
         prob::ODEProblem, alg::SimpleATsit5;
         dt = 0.1, saveat = nothing, save_everystep = true,
         abstol = 1.0e-6, reltol = 1.0e-3,
-        internalnorm = DiffEqBase.ODE_DEFAULT_NORM
+        internalnorm = DiffEqBase.ODE_DEFAULT_NORM, kwargs...
     )
     u0 = prob.u0
     tspan = prob.tspan
@@ -767,7 +774,7 @@ end
         t0 = integrator.t0, dt = integrator.dt
     )
 
-    # Is modifying the `uprev` necessary? We do `u_modified(i, true)`
+    # Is modifying the `uprev` necessary? We do `derivative_discontinuity!(i, true)`
     if isinplace(integrator)
         recursivecopy!(integrator.u, u0)
         recursivecopy!(integrator.uprev, integrator.u)
@@ -775,7 +782,7 @@ end
         integrator.u = u0
         integrator.uprev = integrator.u
     end
-    u_modified!(integrator, true)
+    derivative_discontinuity!(integrator, true)
 
     integrator.t = t0
     integrator.tprev = t0

--- a/src/tsit5/gpuatsit5.jl
+++ b/src/tsit5/gpuatsit5.jl
@@ -50,7 +50,8 @@ export GPUSimpleTsit5
         prob::ODEProblem,
         alg::GPUSimpleTsit5; saveat = nothing,
         save_everystep = true,
-        dt = 0.1f0
+        dt = 0.1f0,
+        kwargs...
     )
     @assert !isinplace(prob)
     u0 = prob.u0
@@ -197,7 +198,8 @@ SciMLBase.isadaptive(alg::GPUSimpleATsit5) = true
         alg::GPUSimpleATsit5;
         dt = 0.1f0, saveat = nothing,
         save_everystep = true,
-        abstol = 1.0f-6, reltol = 1.0f-3
+        abstol = 1.0f-6, reltol = 1.0f-3,
+        kwargs...
     )
     @assert !isinplace(prob)
     u0 = prob.u0

--- a/src/tsit5/tsit5.jl
+++ b/src/tsit5/tsit5.jl
@@ -69,7 +69,7 @@ DiffEqBase.isinplace(::ST5I{IIP}) where {IIP} = IIP
 #######################################################################################
 function DiffEqBase.__init(
         prob::ODEProblem, alg::SimpleTsit5;
-        dt = error("dt is required for this algorithm")
+        dt = error("dt is required for this algorithm"), kwargs...
     )
     return simpletsit5_init(
         prob.f, DiffEqBase.isinplace(prob), prob.u0,
@@ -79,7 +79,7 @@ end
 
 function DiffEqBase.__solve(
         prob::ODEProblem, alg::SimpleTsit5;
-        dt = error("dt is required for this algorithm")
+        dt = error("dt is required for this algorithm"), kwargs...
     )
     u0 = prob.u0
     tspan = prob.tspan

--- a/src/verner/gpuvern7.jl
+++ b/src/verner/gpuvern7.jl
@@ -51,7 +51,8 @@ export GPUSimpleVern7
         prob::ODEProblem,
         alg::GPUSimpleVern7; saveat = nothing,
         save_everystep = true,
-        dt = 0.1f0
+        dt = 0.1f0,
+        kwargs...
     )
     @assert !isinplace(prob)
     u0 = prob.u0
@@ -294,7 +295,8 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern7) = true
         alg::GPUSimpleAVern7;
         dt = 0.1f0, saveat = nothing,
         save_everystep = true,
-        abstol = 1.0f-6, reltol = 1.0f-3
+        abstol = 1.0f-6, reltol = 1.0f-3,
+        kwargs...
     )
     @assert !isinplace(prob)
     u0 = prob.u0

--- a/src/verner/gpuvern9.jl
+++ b/src/verner/gpuvern9.jl
@@ -51,7 +51,8 @@ export GPUSimpleVern9
         prob::ODEProblem,
         alg::GPUSimpleVern9; saveat = nothing,
         save_everystep = true,
-        dt = 0.1f0
+        dt = 0.1f0,
+        kwargs...
     )
     @assert !isinplace(prob)
     u0 = prob.u0
@@ -404,7 +405,8 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern9) = true
         alg::GPUSimpleAVern9;
         dt = 0.1f0, saveat = nothing,
         save_everystep = true,
-        abstol = 1.0f-6, reltol = 1.0f-3
+        abstol = 1.0f-6, reltol = 1.0f-3,
+        kwargs...
     )
     @assert !isinplace(prob)
     u0 = prob.u0

--- a/test/simpleem_tests.jl
+++ b/test/simpleem_tests.jl
@@ -11,7 +11,7 @@ sol = solve(prob, SimpleEM(), dt = 0.25)
 
 @test sol.t == collect(0:0.25:1.0)
 @test length(sol.u) == 5
-@test typeof(sol) <: DESolution
+@test typeof(sol) <: SciMLBase.AbstractSciMLSolution
 
 u0 = @SVector [0.1, 0.2]
 prob = SDEProblem(f, g, u0, tspan)
@@ -51,7 +51,7 @@ prob = SDEProblem(f_oop, g_oop, u0, (0.0, 1.0), noise_rate_prototype = noise_rat
 sol = solve(prob, SimpleEM(), dt = 0.25)
 
 @test length(sol.u) == 5
-@test typeof(sol) <: DESolution
+@test typeof(sol) <: SciMLBase.AbstractSciMLSolution
 
 @info "Non-Diagonal Noise IIP"
 
@@ -71,4 +71,4 @@ prob = SDEProblem(f_oop, g_oop, ones(2), (0.0, 1.0), noise_rate_prototype = zero
 sol = solve(prob, SimpleEM(), dt = 0.25)
 
 @test length(sol.u) == 5
-@test typeof(sol) <: DESolution
+@test typeof(sol) <: SciMLBase.AbstractSciMLSolution


### PR DESCRIPTION
## Summary

Widens the `[compat]` entries so SimpleDiffEq can resolve with the new major releases, and updates the source/tests for the breaking renames:

- `DiffEqBase = "6.122, 7"` (was `"6.122"`)
- `OrdinaryDiffEq = "6, 7"` (was `"6"`)

## Migrations made

- **`u_modified!` -> `derivative_discontinuity!`.** DiffEqBase v7 / SciMLBase v3 renamed this integrator-interface hook. The method extension on `SimpleATsit5Integrator` is now registered on `DiffEqBase.derivative_discontinuity!` when it exists, and falls back to `DiffEqBase.u_modified!` on older DiffEqBase. Both names are re-exported by `SimpleDiffEq` so user code calling either is supported. The internal `u_modified::Bool` field on the integrator struct is kept — only the public hook name changed.
- **`DESolution` removed from DiffEqBase v7.** It was the `Union{DESolution, SciMLSolution}` half of `AbstractSciMLSolution`; the type union was flattened. Dropped from the `@reexport` list and the `simpleem_tests.jl` `typeof(sol) <: DESolution` asserts now use `SciMLBase.AbstractSciMLSolution`, which exists in both SciMLBase v2 and v3.
- **`verbose` kwarg forwarding.** DiffEqBase's top-level `solve`/`init` now always forwards `verbose` (and other preprocessing kwargs) down to the algorithm's `__init`/`__solve`/`solve`. Added `kwargs...` on every SimpleDiffEq dispatch so unrecognized kwargs are swallowed:
  - `SimpleFunctionMap` (`__init`, both `__solve`)
  - `SimpleEuler` (`__init`, `__solve`)
  - `SimpleRK4` (`__init`, `__solve`)
  - `SimpleTsit5` (`__init`, `__solve`)
  - `SimpleATsit5` (`__solve` — `__init` already had it)
  - `SimpleEM` (both `solve` methods)
  - `GPUSimpleEuler`, `GPUSimpleRK4`, `GPUSimpleTsit5`, `GPUSimpleATsit5`, `GPUSimpleVern7`, `GPUSimpleAVern7`, `GPUSimpleVern9`, `GPUSimpleAVern9` (`solve`)

Nothing else from the v7 break list applies to SimpleDiffEq — no `destats`/`has_destats`, no `sol[i]`/`length(sol)`/`iterate(sol)`, no `QuadratureProblem`, no `EnsembleProblem`/`prob_func`/`output_func`, no `fastpow`, no `concrete_solve`, no `constructXxx` tableau functions, no `alias_u0`/`chunk_size`/`standardtag`/`autodiff=true/false`/`lazy=true/false`/`verbose=false` literal flags, no `DEAlgorithm`/`DEProblem` subtyping.

OrdinaryDiffEq v7 does not exist in the General registry yet, so in the test environment OrdinaryDiffEq v6.111 still pins DiffEqBase to v6.218. The code is verified against both resolutions.

Supersedes #107 (the dependabot-style bump), which only edited `Project.toml` and would have failed to precompile.

## Test plan
- [x] `Pkg.test()` passes on Julia 1.10 with the test-env-resolved DiffEqBase v6.218.0 / SciMLBase v2.155.0 / RecursiveArrayTools v3.54.0.
- [x] `using SimpleDiffEq` precompiles and all solver entrypoints (`SimpleEuler`, `SimpleRK4`, `SimpleTsit5`, `SimpleATsit5`, `SimpleFunctionMap`, `SimpleEM`) return correct solutions under DiffEqBase v7.0.0 / SciMLBase v3.4.0 in a side project.
- [x] `ExplicitImports.check_no_implicit_imports` and `check_no_stale_explicit_imports` still return `nothing`.
- [x] `Runic` format check (`--check --diff src test`) returns 0.
- [ ] CI passes on both the regular `Tests.yml` matrix and the `Downgrade.yml` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)