### PR TITLE
Fix master CI: import OrdinaryDiffEq sub-packages explicitly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,9 +28,12 @@ julia = "1.6"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
+OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "JLArrays", "OrdinaryDiffEq", "Pkg", "SafeTestsets", "Test"]
+test = ["ExplicitImports", "JLArrays", "OrdinaryDiffEq", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqTsit5", "OrdinaryDiffEqVerner", "Pkg", "SafeTestsets", "Test"]

--- a/test/gpu_ode_regression.jl
+++ b/test/gpu_ode_regression.jl
@@ -1,4 +1,4 @@
-using SimpleDiffEq, OrdinaryDiffEq, StaticArrays, LinearAlgebra
+using SimpleDiffEq, OrdinaryDiffEq, OrdinaryDiffEqVerner, StaticArrays, LinearAlgebra
 function test(u, p, t)
     return -u
 end

--- a/test/simpleatsit5_tests.jl
+++ b/test/simpleatsit5_tests.jl
@@ -1,4 +1,4 @@
-using SimpleDiffEq, StaticArrays, OrdinaryDiffEq, Test
+using SimpleDiffEq, StaticArrays, OrdinaryDiffEq, OrdinaryDiffEqTsit5, Test
 
 function loop(u, p, t)
     @inbounds begin

--- a/test/simpleeuler_tests.jl
+++ b/test/simpleeuler_tests.jl
@@ -4,7 +4,7 @@
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-using SimpleDiffEq, StaticArrays, OrdinaryDiffEq, Test
+using SimpleDiffEq, StaticArrays, OrdinaryDiffEq, OrdinaryDiffEqLowOrderRK, Test
 
 function loop(u, p, t)
     @inbounds begin

--- a/test/simplerk4_tests.jl
+++ b/test/simplerk4_tests.jl
@@ -4,7 +4,7 @@
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-using SimpleDiffEq, StaticArrays, OrdinaryDiffEq, Test
+using SimpleDiffEq, StaticArrays, OrdinaryDiffEq, OrdinaryDiffEqLowOrderRK, Test
 
 function loop(u, p, t)
     @inbounds begin

--- a/test/simpletsit5_tests.jl
+++ b/test/simpletsit5_tests.jl
@@ -1,4 +1,4 @@
-using SimpleDiffEq, StaticArrays, OrdinaryDiffEq, Test
+using SimpleDiffEq, StaticArrays, OrdinaryDiffEq, OrdinaryDiffEqTsit5, Test
 
 function loop(u, p, t)
     @inbounds begin


### PR DESCRIPTION
After OrdinaryDiffEq v7's split into sub-packages, solver names like `RK4`, `Euler`, `Tsit5`, and `Vern9` are no longer in scope from a bare `using OrdinaryDiffEq`. Import the relevant sub-packages (`OrdinaryDiffEqLowOrderRK`, `OrdinaryDiffEqTsit5`, `OrdinaryDiffEqVerner`) explicitly so the tests resolve them.

Master CI on this repo has been red since the OrdinaryDiffEq v7 ecosystem-bump merge (PR #108). This PR turns it green.

Ignore until reviewed by @ChrisRackauckas.