### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,8 @@ on:
 jobs:
   test:
     if: false  # Disabled: waiting on dependency updates. See #100 for tracking.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI workflows to the centralized SciML reusable workflow callers (pinned `@v1`, every caller gets `secrets: "inherit"`). Tests already used the central caller.

## Converted (inline -> central)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade steps -> `downgrade.yml@v1`, preserving `if: false` (disabled, tracking #100), `julia-version: "1.10"`, `skip: "Pkg,TOML"`, and `ALLOW_RERESOLVE: false` (caller default `allow-reresolve: false`)

## Already central (unchanged)
- **Tests.yml**: already calls `tests.yml@v1` with the full `version × group` matrix and `secrets: "inherit"`
- **TagBot.yml**: unchanged

## Not applicable
- No `docs/make.jl` -> no Documentation caller
- No downstream/benchmark/CompatHelper workflows present

## Cleanup
- **dependabot.yml**: removed the `crate-ci/typos` version ignore (no longer pinned inline); `github-actions` weekly `/`; `julia` daily over dirs with a `Project.toml` (only `/` — `test/` has none, so `/test` was dropped)

## Checks
- Runic: ran locally, **no formatting changes** (repo was already Runic-clean from the inline check)
- typos: ran `typos -w .` then `typos .` -> exit 0, **0 typos fixed**
- All changed YAML validated via `yaml.safe_load`

## Note
Check/job names change (e.g. the Runic, SpellCheck, and Downgrade jobs now run via reusable workflows), so any branch-protection required-status-checks will need updating to match the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)