### PR TITLE
Re-enable downgrade CI with genuine test-at-floor (allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,9 +12,9 @@ on:
       - 'docs/**'
 jobs:
   test:
-    if: false  # Disabled: waiting on dependency updates. See #100 for tracking.
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "1.10"
       skip: "Pkg,TOML"
+      allow-reresolve: false
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -13,15 +13,15 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-DiffEqBase = "6.122, 7"
+DiffEqBase = "6.194.0, 7"
 ExplicitImports = "1.14.0"
 JLArrays = "0.1, 0.2, 0.3"
-MuladdMacro = "0.2"
-OrdinaryDiffEq = "6, 7"
+MuladdMacro = "0.2.4"
+OrdinaryDiffEq = "6.106.0, 7"
 Parameters = "0.12"
-RecursiveArrayTools = "2, 3, 4"
-Reexport = "0.2, 1.0"
-StaticArrays = "0.10, 0.11, 0.12, 1.0"
+RecursiveArrayTools = "3.37.0, 4"
+Reexport = "1.2.2"
+StaticArrays = "1.9.14"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the Downgrade workflow with `allow_reresolve: false` (genuine test-at-floor: tests run at the minimal/downgraded versions). Raises declared-dep `[compat]` lower bounds: `DiffEqBase = "6.194.0, 7";MuladdMacro = "0.2.4";OrdinaryDiffEq = "6.106.0, 7";RecursiveArrayTools = "3.37.0, 4";Reexport = "1.2.2";StaticArrays = "1.9.14";`DiffEqBase = "6.194.0, 7";MuladdMacro = "0.2.4";OrdinaryDiffEq = "6.106.0, 7";RecursiveArrayTools = "3.37.0, 4";Reexport = "1.2.2";StaticArrays = "1.9.14";

Verified locally on Julia 1.10 in a clean depot + fresh registry: downgrade resolve + `Pkg.test(allow_reresolve=false)` pass at the floor with 0 re-resolve. CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)