### PR TITLE
Fix euler inplace interpolation UndefVarError + drop jet_broken (missed by #122)

### DIFF
--- a/src/euler/euler.jl
+++ b/src/euler/euler.jl
@@ -192,14 +192,6 @@ end
     Θ = (t - t₀) / dt
 
     # Hermite interpolation.
-    @inbounds if !isinplace(integ)
-        u = (1 - Θ) * y₀ + Θ * y₁
-        return u
-    else
-        u = similar(y₁)
-        for i in 1:length(u)
-            u[i] = (1 - Θ) * y₀[i] + Θ * y₁[i]
-        end
-        return u
-    end
+    @inbounds u = (1 - Θ) * y₀ + Θ * y₁
+    return u
 end

--- a/src/euler/euler.jl
+++ b/src/euler/euler.jl
@@ -196,8 +196,9 @@ end
         u = (1 - Θ) * y₀ + Θ * y₁
         return u
     else
+        u = similar(y₁)
         for i in 1:length(u)
-            u = @. (1 - Θ) * y₀ + Θ * y₁
+            u[i] = (1 - Θ) * y₀[i] + Θ * y₁[i]
         end
         return u
     end

--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -120,6 +120,7 @@ function SciMLBase.__solve(
     u0 = prob.u0
     tspan = prob.tspan
     ts = Vector{eltype(dt)}(undef, 1)
+    cur_t = 1
 
     if saveat === nothing
         ts = Vector{eltype(dt)}(undef, 1)
@@ -128,7 +129,6 @@ function SciMLBase.__solve(
         push!(us, recursivecopy(u0))
     else
         ts = saveat
-        cur_t = 1
         us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
@@ -282,10 +282,10 @@ end
 
         EEst = integ.internalnorm(tmp, integ.t)
 
+        @fastmath q11 = EEst^beta1
         if iszero(EEst)
             q = inv(qmax)
         else
-            @fastmath q11 = EEst^beta1
             @fastmath q = q11 / (qold^beta2)
         end
 
@@ -367,10 +367,10 @@ end
         tmp = tmp ./ (abstol .+ max.(abs.(uprev), abs.(u)) * reltol)
         EEst = integ.internalnorm(tmp, integ.t)
 
+        @fastmath q11 = EEst^beta1
         if iszero(EEst)
             q = inv(qmax)
         else
-            @fastmath q11 = EEst^beta1
             @fastmath q = q11 / (qold^beta2)
         end
 
@@ -535,10 +535,10 @@ end
 
         EEst = integ.internalnorm(tmp, integ.t)
 
+        @fastmath q11 = EEst^beta1
         if iszero(EEst)
             q = inv(qmax)
         else
-            @fastmath q11 = EEst^beta1
             @fastmath q = q11 / (qold^beta2)
         end
 
@@ -665,10 +665,10 @@ end
 
         EEst = integ.internalnorm(tmp, integ.t)
 
+        @fastmath q11 = EEst^beta1
         if iszero(EEst)
             q = inv(qmax)
         else
-            @fastmath q11 = EEst^beta1
             @fastmath q = q11 / (qold^beta2)
         end
 

--- a/src/tsit5/gpuatsit5.jl
+++ b/src/tsit5/gpuatsit5.jl
@@ -60,6 +60,7 @@ export GPUSimpleTsit5
     p = prob.p
     t = tspan[1]
     tf = tspan[2]
+    cur_t = 1
 
     if saveat === nothing
         ts = Vector{eltype(dt)}(undef, 1)
@@ -68,7 +69,6 @@ export GPUSimpleTsit5
         push!(us, recursivecopy(u0))
     else
         ts = saveat
-        cur_t = 1
         us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
@@ -211,6 +211,7 @@ SciMLBase.isadaptive(alg::GPUSimpleATsit5) = true
 
     t = tspan[1]
     tf = prob.tspan[2]
+    cur_t = 1
 
     if saveat === nothing
         ts = Vector{eltype(dt)}(undef, 1)
@@ -219,7 +220,6 @@ SciMLBase.isadaptive(alg::GPUSimpleATsit5) = true
         push!(us, recursivecopy(u0))
     else
         ts = saveat
-        cur_t = 1
         us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
@@ -267,10 +267,10 @@ SciMLBase.isadaptive(alg::GPUSimpleATsit5) = true
             tmp = tmp ./ (abstol .+ max.(abs.(uprev), abs.(u)) * reltol)
             EEst = DiffEqBase.ODE_DEFAULT_NORM(tmp, t)
 
+            @fastmath q11 = EEst^beta1
             if iszero(EEst)
                 q = inv(qmax)
             else
-                @fastmath q11 = EEst^beta1
                 @fastmath q = q11 / (qold^beta2)
             end
 

--- a/src/verner/gpuvern7.jl
+++ b/src/verner/gpuvern7.jl
@@ -61,6 +61,7 @@ export GPUSimpleVern7
     p = prob.p
     t = tspan[1]
     tf = tspan[2]
+    cur_t = 1
 
     if saveat === nothing
         ts = Vector{eltype(dt)}(undef, 1)
@@ -69,7 +70,6 @@ export GPUSimpleVern7
         push!(us, recursivecopy(u0))
     else
         ts = saveat
-        cur_t = 1
         us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
@@ -308,6 +308,7 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern7) = true
 
     t = tspan[1]
     tf = prob.tspan[2]
+    cur_t = 1
 
     if saveat === nothing
         ts = Vector{eltype(dt)}(undef, 1)
@@ -316,7 +317,6 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern7) = true
         push!(us, recursivecopy(u0))
     else
         ts = saveat
-        cur_t = 1
         us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
@@ -396,10 +396,10 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern7) = true
             tmp = tmp ./ (abstol .+ max.(abs.(uprev), abs.(u)) * reltol)
             EEst = DiffEqBase.ODE_DEFAULT_NORM(tmp, t)
 
+            @fastmath q11 = EEst^beta1
             if iszero(EEst)
                 q = inv(qmax)
             else
-                @fastmath q11 = EEst^beta1
                 @fastmath q = q11 / (qold^beta2)
             end
 

--- a/src/verner/gpuvern9.jl
+++ b/src/verner/gpuvern9.jl
@@ -61,6 +61,7 @@ export GPUSimpleVern9
     p = prob.p
     t = tspan[1]
     tf = tspan[2]
+    cur_t = 1
 
     if saveat === nothing
         ts = Vector{eltype(dt)}(undef, 1)
@@ -69,7 +70,6 @@ export GPUSimpleVern9
         push!(us, recursivecopy(u0))
     else
         ts = saveat
-        cur_t = 1
         us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
@@ -418,6 +418,7 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern9) = true
 
     t = tspan[1]
     tf = prob.tspan[2]
+    cur_t = 1
 
     if saveat === nothing
         ts = Vector{eltype(dt)}(undef, 1)
@@ -426,7 +427,6 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern9) = true
         push!(us, recursivecopy(u0))
     else
         ts = saveat
-        cur_t = 1
         us = MVector{Int(length(ts)), typeof(u0)}(undef)
         if prob.tspan[1] == ts[1]
             cur_t += 1
@@ -564,10 +564,10 @@ SciMLBase.isadaptive(alg::GPUSimpleAVern9) = true
             k9 = k15
             k10 = k16
 
+            @fastmath q11 = EEst^beta1
             if iszero(EEst)
                 q = inv(qmax)
             else
-                @fastmath q11 = EEst^beta1
                 @fastmath q = q11 / (qold^beta2)
             end
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,22 +1,7 @@
 using SciMLTesting, SimpleDiffEq, Test
 using JET
 
-# JET `report_package(; mode = :typo)` is clean on Julia 1.10/1.11 (JET 0.9.x) but
-# surfaces 36 reports on Julia 1.12 (JET 0.11.x): one genuine latent bug
-# (src/euler/euler.jl:199, an inplace-interpolation path that reads `length(u)`
-# before `u` is assigned) and ~35 `may be undefined` reports on correlated-branch
-# control flow (`cur_t` in the tsit5 `solve`/`gpuatsit5`/`gpuvern` loops, `q11` in
-# the adaptive `step!` error-estimate blocks) that the earlier JET could prove safe
-# but JET 0.11 cannot. The source is byte-identical to master, so these predate this
-# QA conversion. Mark the JET check known-broken on 1.12+ (tracked in
-# SciML/SimpleDiffEq.jl#123); the marker auto-flips to an Unexpected Pass when the
-# reports are resolved. Gated by VERSION so the still-clean 1.10/1.11 lanes keep
-# running the hard `test_package` check (a blanket `jet_broken` would record an
-# Unexpected-Pass error there).
-const jet_broken = VERSION >= v"1.12"
-
 run_qa(
     SimpleDiffEq;
     explicit_imports = true,
-    jet_broken = jet_broken,
 )


### PR DESCRIPTION
## Summary

#122 was squash-merged (`e49d143`) **before** the fix commit `1b34213` landed, so current `master` is missing that fix. This PR applies the stranded fix onto current master. It contains one real bug fix plus behavior-preserving restructures that let the hard JET `test_package` check run on all lanes.

### The real bug

`src/euler/euler.jl` — the inplace Hermite-interpolation branch read `length(u)` **before** `u` was ever assigned (a guaranteed `UndefVarError` on that path) and looped pointlessly reassigning a whole broadcast. Rewritten to match the `rk4`/`tsit5` siblings: allocate `u = similar(y₁)` first, then fill element-wise with the same linear interpolant the out-of-place branch returns (`(1 - Θ)*y₀ + Θ*y₁`).

Verified on Julia 1.12 that the old code throws `UndefVarError: u not defined in local scope`, and the fixed code returns the correct linear interpolant.

### JET false-positive restructures (behavior-preserving)

- **`cur_t` hoist** — in `atsit5.jl __solve`, `gpuatsit5.jl`, `gpuvern7.jl`, `gpuvern9.jl`: hoist the `cur_t = 1` initializer above the `saveat` if/else so it is unconditionally defined. It is read only when `saveat !== nothing`, and the else branch already re-established it, so runtime behavior is unchanged; JET can now prove it defined.
- **`q11` hoist** — in the adaptive `step!` methods (`atsit5.jl` ×5) and the `gpuatsit5`/`gpuvern7`/`gpuvern9` error-estimate blocks: compute `@fastmath q11 = EEst^beta1` before the `iszero(EEst)` guard. `q11` is read only when `EEst > 1` (which implies `EEst != 0`), and when `iszero(EEst)` the value is never used, so this is behavior-preserving; JET can now prove it defined.

### QA marker drop

`test/qa/qa.jl` — drop `const jet_broken = VERSION >= v"1.12"` and the `jet_broken` kwarg, leaving a plain `run_qa(SimpleDiffEq; explicit_imports = true)`. The hard `test_package` JET check now runs on all lanes.

## Verification (run locally)

- **JET on Julia 1.12.6 (JET 0.11.5):** `report_package(SimpleDiffEq; mode = :typo, target_defined_modules = true)` returns **0 reports** (was 36).
- **Euler inplace interpolation path:** returns the correct linear interpolant, no `UndefVarError`.
- **Core group on Julia 1.10:** all test files pass (`SimpleDiffEq tests passed`), incl. the adaptive `step!`, saveat interpolation, and GPU solve paths that were restructured (only the 1 pre-existing `@test_broken` in `discrete_tests.jl` remains broken).

---

Please ignore until reviewed by @ChrisRackauckas.
