### PR TITLE
Bump version to 1.16.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimpleDiffEq"
 uuid = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
-version = "1.16.0"
+version = "1.16.1"
 repo = "https://github.com/SciML/SimpleDiffEq.jl.git"
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (1.16.0 -> 1.16.1) to release unreleased commits on `master` via JuliaRegistrator.