### PR TITLE
Document SimpleDiffEq public API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+docs/build/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ These solvers are designed for GPU compatibility (out-of-place only):
 
 | Algorithm | Description |
 |-----------|-------------|
+| `GPUSimpleEuler` | GPU-compatible forward Euler |
 | `GPUSimpleRK4` | GPU-compatible RK4 |
 | `GPUSimpleTsit5` | GPU-compatible Tsit5 (fixed step) |
 | `GPUSimpleATsit5` | GPU-compatible adaptive Tsit5 |

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SimpleDiffEq = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
+
+[sources]
+SimpleDiffEq = { path = ".." }
+
+[compat]
+Documenter = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,18 @@
+using Documenter
+using SimpleDiffEq
+
+DocMeta.setdocmeta!(SimpleDiffEq, :DocTestSetup, :(using SimpleDiffEq); recursive = true)
+
+makedocs(;
+    modules = [SimpleDiffEq],
+    sitename = "SimpleDiffEq.jl",
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://docs.sciml.ai/SimpleDiffEq/stable/"
+    ),
+    pages = [
+        "Home" => "index.md",
+    ],
+    checkdocs = :exports,
+    warnonly = false
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,66 @@
+# SimpleDiffEq.jl
+
+SimpleDiffEq.jl provides compact differential equation solvers that implement
+the SciML common solve interface without the broader feature set of the full
+solver packages.
+
+## Algorithms
+
+```@docs
+SimpleEuler
+LoopEuler
+SimpleRK4
+LoopRK4
+SimpleTsit5
+SimpleATsit5
+GPUSimpleEuler
+GPUSimpleRK4
+GPUSimpleTsit5
+GPUSimpleATsit5
+GPUSimpleVern7
+GPUSimpleAVern7
+GPUSimpleVern9
+GPUSimpleAVern9
+SimpleEM
+SimpleFunctionMap
+```
+
+## Compatibility Hooks
+
+```@docs
+u_modified!
+```
+
+## Reexported SciML Interface
+
+SimpleDiffEq also reexports these upstream SciML interface names for
+convenience:
+
+<!-- public-api-reexports-start -->
+- `@..`
+- `AbstractODEAlgorithm`
+- `AbstractODEIntegrator`
+- `AbstractSDEAlgorithm`
+- `ConstantInterpolation`
+- `DEIntegrator`
+- `DiffEqBase`
+- `DiscreteProblem`
+- `ODEProblem`
+- `ODE_DEFAULT_NORM`
+- `SDEProblem`
+- `SciMLBase`
+- `__init`
+- `__solve`
+- `build_solution`
+- `calculate_solution_errors!`
+- `derivative_discontinuity!`
+- `has_analytic`
+- `init`
+- `is_diagonal_noise`
+- `isdiscrete`
+- `isinplace`
+- `reinit!`
+- `set_t!`
+- `solve`
+- `step!`
+<!-- public-api-reexports-end -->

--- a/src/SimpleDiffEq.jl
+++ b/src/SimpleDiffEq.jl
@@ -28,6 +28,27 @@ module SimpleDiffEq
     @static if isdefined(DiffEqBase, :u_modified!)
         using DiffEqBase: u_modified!
         export u_modified!
+        @doc """
+            u_modified!(integrator, modified::Bool)
+
+        Mark whether an integrator state was externally modified.
+
+        # Arguments
+
+        - `integrator`: A SciML integrator that supports the mutation hook.
+        - `modified::Bool`: Whether the current state should be treated as modified.
+
+        # Returns
+
+        Returns the implementation-defined result of the integrator hook.
+
+        # Notes
+
+        This is the legacy DiffEqBase compatibility name for
+        `derivative_discontinuity!`. SimpleDiffEq reexports it when the
+        installed DiffEqBase/SciMLBase stack still provides the binding.
+        """
+        SciMLBase.u_modified!
     end
     using StaticArrays: SArray, SVector, MVector
     using RecursiveArrayTools: recursivecopy!

--- a/src/euler/euler.jl
+++ b/src/euler/euler.jl
@@ -5,19 +5,32 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 """
-    SimpleEuler
+    SimpleEuler()
 
-Forward Euler method for solving ODEs.
+Construct a fixed-step forward Euler algorithm for `ODEProblem`s.
 
-This is the simplest explicit ODE solver, using first-order accurate forward Euler steps.
-It requires a fixed time step `dt` and supports both in-place and out-of-place formulations.
+`SimpleEuler` advances ordinary differential equations with first-order explicit
+Euler steps. It supports in-place and out-of-place problem functions and the
+SciML integrator interface.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass `dt` to `solve` or
+`init`.
+
+# Returns
+
+A `SimpleEuler` algorithm object for use with `ODEProblem`.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE: du/dt = f(u, p, t)
 f(u, p, t) = -0.5 * u
 
 u0 = 1.0
@@ -27,21 +40,14 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, SimpleEuler(), dt = 0.1)
 ```
 
-## Required Parameters
+# Notes
 
-- `dt`: Fixed time step size
+`dt` is required. Use `init` and `step!` for manual stepping or
+dense interpolation over the most recent step.
 
-## Features
+# See Also
 
-- 1st order accurate
-- Both in-place and out-of-place support
-- Integrator interface via `init` and `step!`
-- Minimal computational overhead
-
-## See also
-
-- [`LoopEuler`](@ref) for a teaching/benchmarking variant
-- [`SimpleRK4`](@ref) for higher accuracy with 4th order method
+[`LoopEuler`](@ref), [`SimpleRK4`](@ref)
 """
 struct SimpleEuler <: AbstractSimpleDiffEqODEAlgorithm end
 export SimpleEuler

--- a/src/euler/gpueuler.jl
+++ b/src/euler/gpueuler.jl
@@ -5,19 +5,31 @@
 #######################################################################################
 
 """
-    GPUSimpleEuler
+    GPUSimpleEuler()
 
-GPU-compatible forward Euler method.
+Construct a GPU-compatible fixed-step forward Euler algorithm.
 
-This is a simplified forward Euler implementation designed for GPU compatibility. It only
-supports out-of-place formulations and uses static arrays for efficiency on GPU architectures.
+`GPUSimpleEuler` is a small out-of-place Euler implementation intended for GPU
+kernels and static-array workloads.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass `dt` to `solve`.
+
+# Returns
+
+A `GPUSimpleEuler` algorithm object for use with out-of-place `ODEProblem`
+definitions.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE (out-of-place only)
 f(u, p, t) = -0.5 * u
 
 u0 = 1.0
@@ -27,19 +39,13 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, GPUSimpleEuler(), dt = 0.1)
 ```
 
-## Required Parameters
+# Notes
 
-- `dt`: Fixed time step size
+`dt` is required. In-place problem functions are not supported.
 
-## Restrictions
+# See Also
 
-- Out-of-place formulations only
-- Optimized for GPU execution
-
-## See also
-
-- [`SimpleEuler`](@ref) for the standard CPU-optimized version
-- [`GPUSimpleRK4`](@ref) for higher accuracy GPU solver
+[`SimpleEuler`](@ref), [`GPUSimpleRK4`](@ref)
 """
 struct GPUSimpleEuler <: AbstractSimpleDiffEqODEAlgorithm end
 export GPUSimpleEuler

--- a/src/euler/loopeuler.jl
+++ b/src/euler/loopeuler.jl
@@ -4,20 +4,32 @@
 #######################################################################################
 
 """
-    LoopEuler
+    LoopEuler()
 
-Simplified loop-based forward Euler method for teaching and benchmarking.
+Construct a minimal loop-based forward Euler algorithm.
 
-This is a minimal forward Euler implementation with explicit loops, designed for educational
-purposes and to benchmark the overhead of more sophisticated integrators. It supports both
-in-place and out-of-place formulations but without advanced features.
+`LoopEuler` uses direct loops to expose the method structure for teaching and
+benchmarking. It supports in-place and out-of-place `ODEProblem`s but omits the
+integrator features provided by `SimpleEuler`.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time keywords such as `dt`,
+`save_everystep`, and `save_start` to `solve`.
+
+# Returns
+
+A `LoopEuler` algorithm object for use with `ODEProblem`.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE
 f(u, p, t) = -0.5 * u
 
 u0 = 1.0
@@ -27,20 +39,13 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, LoopEuler(), dt = 0.1)
 ```
 
-## Required Parameters
+# Notes
 
-- `dt`: Fixed time step size
+`dt` is required. `adaptive = true` and `dense = true` are not supported.
 
-## Use Cases
+# See Also
 
-- Teaching how Euler's method works
-- Benchmarking integrator overhead
-- Minimal dependencies for simple problems
-
-## See also
-
-- [`SimpleEuler`](@ref) for a more optimized version
-- [`LoopRK4`](@ref) for a higher order teaching variant
+[`SimpleEuler`](@ref), [`LoopRK4`](@ref)
 """
 struct LoopEuler <: AbstractSimpleDiffEqODEAlgorithm end
 export LoopEuler

--- a/src/euler_maruyama.jl
+++ b/src/euler_maruyama.jl
@@ -1,17 +1,29 @@
 """
-    SimpleEM
+    SimpleEM()
 
-Euler-Maruyama method for solving stochastic differential equations (SDEs).
+Construct a fixed-step Euler-Maruyama algorithm for `SDEProblem`s.
 
-This is a simple, first-order strong convergence method for SDEs. It supports both
-diagonal and non-diagonal noise. The algorithm requires a fixed time step `dt`.
+`SimpleEM` applies the Euler-Maruyama method to stochastic differential
+equations. It supports in-place and out-of-place drift/diffusion functions, and
+handles diagonal and non-diagonal noise.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass `dt` to `solve`.
+
+# Returns
+
+A `SimpleEM` algorithm object for use with `SDEProblem`.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define SDE: du = f(u,p,t)dt + g(u,p,t)dW
 f(u, p, t) = 0.1u
 g(u, p, t) = 0.2u
 
@@ -19,17 +31,16 @@ u0 = 1.0
 tspan = (0.0, 1.0)
 prob = SDEProblem(f, g, u0, tspan)
 
-# Solve with fixed step size
 sol = solve(prob, SimpleEM(), dt = 0.01)
 ```
 
-## Required Parameters
+# Notes
 
-- `dt`: Fixed time step size
+`dt` is required. The method has strong order `1/2` for general SDEs.
 
-## See also
+# See Also
 
-- [`SDEProblem`](@ref) for problem setup
+`SDEProblem`
 """
 struct SimpleEM <: SciMLBase.AbstractSDEAlgorithm end
 export SimpleEM

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -1,36 +1,49 @@
 """
-    SimpleFunctionMap
+    SimpleFunctionMap()
 
-Simple function iteration for discrete problems.
+Construct a simple function-map algorithm for `DiscreteProblem`s.
 
-This algorithm iterates a discrete map of the form `u[n+1] = f(u[n], p, t[n+1])`.
-It is used for discrete dynamical systems and difference equations.
+`SimpleFunctionMap` advances discrete dynamical systems with
+`u[n+1] = f(u[n], p, t[n+1])` for out-of-place maps, or
+`f!(u[n+1], u[n], p, t[n+1])` for in-place maps. The time step is fixed at one
+unit of the problem time axis.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time options such as
+`calculate_values` to `solve` or `init`.
+
+# Returns
+
+A `SimpleFunctionMap` algorithm object for use with `DiscreteProblem`.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define discrete map: u[n+1] = f(u[n], p, t)
-f(u, p, t) = p * u * (1 - u)  # Logistic map
+f(u, p, t) = p * u * (1 - u)
 
 u0 = 0.5
-tspan = (0.0, 100.0)  # Will iterate for 101 steps (0 to 100)
+tspan = (0.0, 100.0)
 p = 3.2
 
 prob = DiscreteProblem(f, u0, tspan, p)
 sol = solve(prob, SimpleFunctionMap())
 ```
 
-## Notes
+# Notes
 
-- The time step is always 1 for discrete problems
-- Both in-place and out-of-place forms are supported
-- Supports the integrator interface via `init` and `step!`
+Both in-place and out-of-place maps are supported. The algorithm also supports
+the integrator interface through `init` and `step!`.
 
-## See also
+# See Also
 
-- [`DiscreteProblem`](@ref) for problem setup
+`DiscreteProblem`
 """
 struct SimpleFunctionMap end
 export SimpleFunctionMap

--- a/src/rk4/gpurk4.jl
+++ b/src/rk4/gpurk4.jl
@@ -5,19 +5,31 @@
 #######################################################################################
 
 """
-    GPUSimpleRK4
+    GPUSimpleRK4()
 
-GPU-compatible classic Runge-Kutta 4th order method.
+Construct a GPU-compatible fixed-step fourth-order Runge-Kutta algorithm.
 
-This is a simplified RK4 implementation designed for GPU compatibility. It only supports
-out-of-place formulations and uses static arrays for efficiency on GPU architectures.
+`GPUSimpleRK4` is an out-of-place RK4 implementation intended for GPU kernels
+and static-array workloads.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass `dt` to `solve`.
+
+# Returns
+
+A `GPUSimpleRK4` algorithm object for use with out-of-place `ODEProblem`
+definitions.
+
+# Example
 
 ```julia
 using SimpleDiffEq, StaticArrays
 
-# Define ODE (out-of-place only)
 f(u, p, t) = -u
 
 u0 = 1.0
@@ -27,19 +39,13 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, GPUSimpleRK4(), dt = 0.1)
 ```
 
-## Required Parameters
+# Notes
 
-- `dt`: Fixed time step size
+`dt` is required. In-place problem functions are not supported.
 
-## Restrictions
+# See Also
 
-- Out-of-place formulations only (no in-place mutations)
-- Optimized for GPU execution
-
-## See also
-
-- [`SimpleRK4`](@ref) for the standard CPU-optimized version
-- [`LoopRK4`](@ref) for a teaching-focused variant
+[`SimpleRK4`](@ref), [`LoopRK4`](@ref)
 """
 struct GPUSimpleRK4 <: AbstractSimpleDiffEqODEAlgorithm end
 export GPUSimpleRK4

--- a/src/rk4/looprk4.jl
+++ b/src/rk4/looprk4.jl
@@ -4,20 +4,32 @@
 #######################################################################################
 
 """
-    LoopRK4
+    LoopRK4()
 
-Simplified loop-based Runge-Kutta 4th order method for teaching and benchmarking.
+Construct a minimal loop-based fourth-order Runge-Kutta algorithm.
 
-This is a minimal RK4 implementation with explicit loops, designed for educational purposes
-and to benchmark the overhead of more sophisticated integrators. It supports both in-place
-and out-of-place formulations but without advanced features like interpolation or FSAL.
+`LoopRK4` uses direct loops to expose the RK4 method structure for teaching and
+benchmarking. It supports in-place and out-of-place `ODEProblem`s but omits the
+integrator features provided by `SimpleRK4`.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time keywords such as `dt`,
+`save_everystep`, and `save_start` to `solve`.
+
+# Returns
+
+A `LoopRK4` algorithm object for use with `ODEProblem`.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
@@ -27,20 +39,13 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, LoopRK4(), dt = 0.1)
 ```
 
-## Required Parameters
+# Notes
 
-- `dt`: Fixed time step size
+`dt` is required. `adaptive = true` and `dense = true` are not supported.
 
-## Use Cases
+# See Also
 
-- Teaching how RK4 works
-- Benchmarking integrator overhead
-- Minimal dependencies for simple problems
-
-## See also
-
-- [`SimpleRK4`](@ref) for a more optimized version with FSAL and interpolation
-- [`GPUSimpleRK4`](@ref) for GPU-compatible version
+[`SimpleRK4`](@ref), [`GPUSimpleRK4`](@ref)
 """
 struct LoopRK4 <: AbstractSimpleDiffEqODEAlgorithm end
 export LoopRK4

--- a/src/rk4/rk4.jl
+++ b/src/rk4/rk4.jl
@@ -5,47 +5,48 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 """
-    SimpleRK4
+    SimpleRK4()
 
-Classic Runge-Kutta 4th order method for solving ODEs.
+Construct a fixed-step classical fourth-order Runge-Kutta algorithm.
 
-This is the standard RK4 method, a widely-used explicit Runge-Kutta method with
-4th order accuracy. It requires a fixed time step `dt` and supports both in-place
-and out-of-place formulations. The implementation uses FSAL (First Same As Last)
-optimization and supports interpolation via Hermite polynomials.
+`SimpleRK4` solves `ODEProblem`s with the classical explicit RK4 method. It
+supports in-place and out-of-place problem functions, dense interpolation over
+the most recent step, and the SciML integrator interface.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass `dt` to `solve` or
+`init`.
+
+# Returns
+
+A `SimpleRK4` algorithm object for use with `ODEProblem`.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE: du/dt = f(u, p, t)
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
 tspan = (0.0, 10.0)
 prob = ODEProblem(f, u0, tspan)
 
-# Solve with fixed step size
 sol = solve(prob, SimpleRK4(), dt = 0.1)
 ```
 
-## Required Parameters
+# Notes
 
-- `dt`: Fixed time step size
+`dt` is required. Use `init` and `step!` for manual stepping.
 
-## Features
+# See Also
 
-- 4th order accurate
-- FSAL optimization for efficiency
-- Hermite interpolation for dense output
-- Both in-place and out-of-place support
-- Integrator interface via `init` and `step!`
-
-## See also
-
-- [`LoopRK4`](@ref) for a simpler teaching/benchmarking variant
-- [`GPUSimpleRK4`](@ref) for GPU-compatible version
+[`LoopRK4`](@ref), [`GPUSimpleRK4`](@ref)
 """
 struct SimpleRK4 <: AbstractSimpleDiffEqODEAlgorithm end
 export SimpleRK4

--- a/src/tsit5/atsit5.jl
+++ b/src/tsit5/atsit5.jl
@@ -1,49 +1,52 @@
 using RecursiveArrayTools: recursivecopy
 
 """
-    SimpleATsit5
+    SimpleATsit5()
 
-Adaptive Tsitouras 5th order Runge-Kutta method.
+Construct an adaptive Tsitouras fifth-order Runge-Kutta algorithm.
 
-This is an adaptive step size version of the Tsitouras 5th order method, using PI-controlled
-adaptive stepping based on error estimates. It automatically adjusts the step size to meet
-specified absolute and relative tolerances.
+`SimpleATsit5` solves `ODEProblem`s with the Tsitouras 5/4 embedded
+Runge-Kutta method and PI-controlled adaptive step sizes. It supports in-place
+and out-of-place problem functions, interpolation, and optional `saveat`
+sampling.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time keywords such as `dt`,
+`abstol`, `reltol`, `internalnorm`, `saveat`, and `save_everystep` to
+`solve` or `init`.
+
+# Returns
+
+A `SimpleATsit5` algorithm object for use with `ODEProblem`.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
 tspan = (0.0, 10.0)
 prob = ODEProblem(f, u0, tspan)
 
-# Adaptive stepping with tolerance control
 sol = solve(prob, SimpleATsit5(), dt = 0.1, abstol = 1e-6, reltol = 1e-3)
 ```
 
-## Parameters
+# Notes
 
-- `dt`: Initial time step size (default: 0.1)
-- `abstol`: Absolute tolerance (default: 1e-6)
-- `reltol`: Relative tolerance (default: 1e-3)
-- `internalnorm`: Norm function for error estimation (default: ODE_DEFAULT_NORM)
+The default initial step is `dt = 0.1`, with `abstol = 1e-6` and
+`reltol = 1e-3`. The integrator hook `derivative_discontinuity!` marks
+the cached derivative as stale after external state changes.
 
-## Features
+# See Also
 
-- Adaptive step size control with PI controller
-- 5th order accurate with embedded error estimator
-- Continuous interpolation for dense output
-- Both in-place and out-of-place support
-- Optional `saveat` for saving at specific times
-
-## See also
-
-- [`SimpleTsit5`](@ref) for the fixed step size version
-- [`GPUSimpleATsit5`](@ref) for GPU-compatible version
+[`SimpleTsit5`](@ref), [`GPUSimpleATsit5`](@ref)
 """
 struct SimpleATsit5 <: AbstractSimpleDiffEqODEAlgorithm end
 export SimpleATsit5

--- a/src/tsit5/gpuatsit5.jl
+++ b/src/tsit5/gpuatsit5.jl
@@ -5,19 +5,32 @@
 #######################################################################################
 
 """
-    GPUSimpleTsit5
+    GPUSimpleTsit5()
 
-GPU-compatible Tsitouras 5th order Runge-Kutta method with fixed time step.
+Construct a GPU-compatible fixed-step Tsitouras fifth-order algorithm.
 
-This is a GPU-optimized version of the Tsitouras 5th order method with a fixed step size.
-It only supports out-of-place formulations for compatibility with GPU kernels.
+`GPUSimpleTsit5` is an out-of-place Tsitouras 5/4 implementation intended for
+GPU kernels and static-array workloads.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time keywords such as `dt`,
+`saveat`, and `save_everystep` to `solve`.
+
+# Returns
+
+A `GPUSimpleTsit5` algorithm object for use with out-of-place
+`ODEProblem` definitions.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE (out-of-place only)
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
@@ -27,21 +40,14 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, GPUSimpleTsit5(), dt = 0.1)
 ```
 
-## Parameters
+# Notes
 
-- `dt`: Fixed time step size (default: 0.1)
-- `saveat`: Optional times to save solution at
-- `save_everystep`: Save at every step (default: true)
+The default step size is `dt = 0.1f0`. In-place problem functions are not
+supported.
 
-## Restrictions
+# See Also
 
-- Out-of-place formulations only
-- Optimized for GPU execution
-
-## See also
-
-- [`GPUSimpleATsit5`](@ref) for the adaptive step size version
-- [`SimpleTsit5`](@ref) for the CPU-optimized version
+[`GPUSimpleATsit5`](@ref), [`SimpleTsit5`](@ref)
 """
 struct GPUSimpleTsit5 <: AbstractSimpleDiffEqODEAlgorithm end
 export GPUSimpleTsit5
@@ -147,19 +153,32 @@ end
 #######################################################################################
 
 """
-    GPUSimpleATsit5
+    GPUSimpleATsit5()
 
-GPU-compatible adaptive Tsitouras 5th order Runge-Kutta method.
+Construct a GPU-compatible adaptive Tsitouras fifth-order algorithm.
 
-This is a GPU-optimized version of the adaptive Tsitouras 5th order method with
-PI-controlled adaptive stepping. It only supports out-of-place formulations.
+`GPUSimpleATsit5` is an out-of-place adaptive Tsitouras 5/4 implementation
+intended for GPU kernels and static-array workloads.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time keywords such as `dt`,
+`abstol`, `reltol`, `saveat`, and `save_everystep` to `solve`.
+
+# Returns
+
+A `GPUSimpleATsit5` algorithm object for use with out-of-place
+`ODEProblem` definitions.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE (out-of-place only)
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
@@ -169,24 +188,14 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, GPUSimpleATsit5(), dt = 0.1, abstol = 1e-6, reltol = 1e-3)
 ```
 
-## Parameters
+# Notes
 
-- `dt`: Initial time step size (default: 0.1)
-- `abstol`: Absolute tolerance (default: 1e-6)
-- `reltol`: Relative tolerance (default: 1e-3)
-- `saveat`: Optional times to save solution at
-- `save_everystep`: Save at every step (default: true)
+The default initial step is `dt = 0.1f0`, with `abstol = 1f-6` and
+`reltol = 1f-3`. In-place problem functions are not supported.
 
-## Restrictions
+# See Also
 
-- Out-of-place formulations only
-- Optimized for GPU execution
-
-## See also
-
-- [`GPUSimpleTsit5`](@ref) for the fixed step size version
-- [`SimpleATsit5`](@ref) for the CPU-optimized version
-- [`GPUSimpleAVern7`](@ref) for higher order adaptive method
+[`GPUSimpleTsit5`](@ref), [`SimpleATsit5`](@ref), [`GPUSimpleAVern7`](@ref)
 """
 struct GPUSimpleATsit5 end
 export GPUSimpleATsit5

--- a/src/tsit5/tsit5.jl
+++ b/src/tsit5/tsit5.jl
@@ -1,18 +1,30 @@
 """
-    SimpleTsit5
+    SimpleTsit5()
 
-Tsitouras 5th order Runge-Kutta method with fixed time step.
+Construct a fixed-step Tsitouras fifth-order Runge-Kutta algorithm.
 
-This is a 5th order explicit Runge-Kutta method developed by Tsitouras, using a fixed
-time step. It provides higher accuracy than RK4 while still being efficient. Supports
-both in-place and out-of-place formulations with continuous interpolation.
+`SimpleTsit5` solves `ODEProblem`s with the Tsitouras 5/4 explicit Runge-Kutta
+method using a fixed step size. It supports in-place and out-of-place problem
+functions, continuous interpolation, and the SciML integrator interface.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass `dt` to `solve` or
+`init`.
+
+# Returns
+
+A `SimpleTsit5` algorithm object for use with `ODEProblem`.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
@@ -22,22 +34,14 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, SimpleTsit5(), dt = 0.1)
 ```
 
-## Required Parameters
+# Notes
 
-- `dt`: Fixed time step size
+`dt` is required. Use [`SimpleATsit5`](@ref) when adaptive step sizes are
+needed.
 
-## Features
+# See Also
 
-- 5th order accurate
-- Continuous interpolation for dense output
-- FSAL optimization
-- Both in-place and out-of-place support
-
-## See also
-
-- [`SimpleATsit5`](@ref) for the adaptive step size version
-- [`GPUSimpleTsit5`](@ref) for GPU-compatible version
-- [`SimpleRK4`](@ref) for a lower order alternative
+[`SimpleATsit5`](@ref), [`GPUSimpleTsit5`](@ref), [`SimpleRK4`](@ref)
 """
 struct SimpleTsit5 <: AbstractSimpleDiffEqODEAlgorithm end
 export SimpleTsit5

--- a/src/verner/gpuvern7.jl
+++ b/src/verner/gpuvern7.jl
@@ -5,20 +5,32 @@
 #######################################################################################
 
 """
-    GPUSimpleVern7
+    GPUSimpleVern7()
 
-GPU-compatible Verner 7th order Runge-Kutta method with fixed time step.
+Construct a GPU-compatible fixed-step Verner seventh-order algorithm.
 
-This is a 7th order explicit Runge-Kutta method designed for GPU compatibility.
-It only supports out-of-place formulations and provides very high accuracy for
-smooth problems.
+`GPUSimpleVern7` is an out-of-place Verner 7/6 explicit Runge-Kutta
+implementation intended for GPU kernels and static-array workloads.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time keywords such as `dt`,
+`saveat`, and `save_everystep` to `solve`.
+
+# Returns
+
+A `GPUSimpleVern7` algorithm object for use with out-of-place
+`ODEProblem` definitions.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE (out-of-place only)
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
@@ -28,21 +40,14 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, GPUSimpleVern7(), dt = 0.1)
 ```
 
-## Parameters
+# Notes
 
-- `dt`: Fixed time step size (default: 0.1)
-- `saveat`: Optional times to save solution at
-- `save_everystep`: Save at every step (default: true)
+The default step size is `dt = 0.1f0`. In-place problem functions are not
+supported.
 
-## Restrictions
+# See Also
 
-- Out-of-place formulations only
-- Optimized for GPU execution
-
-## See also
-
-- [`GPUSimpleAVern7`](@ref) for the adaptive step size version
-- [`GPUSimpleVern9`](@ref) for even higher order accuracy
+[`GPUSimpleAVern7`](@ref), [`GPUSimpleVern9`](@ref)
 """
 struct GPUSimpleVern7 <: AbstractSimpleDiffEqODEAlgorithm end
 export GPUSimpleVern7
@@ -243,20 +248,32 @@ end
 #######################################################################################
 
 """
-    GPUSimpleAVern7
+    GPUSimpleAVern7()
 
-GPU-compatible adaptive Verner 7th order Runge-Kutta method.
+Construct a GPU-compatible adaptive Verner seventh-order algorithm.
 
-This is a GPU-optimized adaptive version of the Verner 7th order method with PI-controlled
-adaptive stepping. It only supports out-of-place formulations and provides very high accuracy
-with automatic step size control.
+`GPUSimpleAVern7` is an out-of-place adaptive Verner 7/6 explicit Runge-Kutta
+implementation intended for GPU kernels and static-array workloads.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time keywords such as `dt`,
+`abstol`, `reltol`, `saveat`, and `save_everystep` to `solve`.
+
+# Returns
+
+A `GPUSimpleAVern7` algorithm object for use with out-of-place
+`ODEProblem` definitions.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE (out-of-place only)
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
@@ -266,24 +283,14 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, GPUSimpleAVern7(), dt = 0.1, abstol = 1e-6, reltol = 1e-3)
 ```
 
-## Parameters
+# Notes
 
-- `dt`: Initial time step size (default: 0.1)
-- `abstol`: Absolute tolerance (default: 1e-6)
-- `reltol`: Relative tolerance (default: 1e-3)
-- `saveat`: Optional times to save solution at
-- `save_everystep`: Save at every step (default: true)
+The default initial step is `dt = 0.1f0`, with `abstol = 1f-6` and
+`reltol = 1f-3`. In-place problem functions are not supported.
 
-## Restrictions
+# See Also
 
-- Out-of-place formulations only
-- Optimized for GPU execution
-
-## See also
-
-- [`GPUSimpleVern7`](@ref) for the fixed step size version
-- [`GPUSimpleAVern9`](@ref) for even higher order adaptive method
-- [`GPUSimpleATsit5`](@ref) for a lower order adaptive alternative
+[`GPUSimpleVern7`](@ref), [`GPUSimpleAVern9`](@ref), [`GPUSimpleATsit5`](@ref)
 """
 struct GPUSimpleAVern7 end
 export GPUSimpleAVern7

--- a/src/verner/gpuvern9.jl
+++ b/src/verner/gpuvern9.jl
@@ -5,20 +5,32 @@
 #######################################################################################
 
 """
-    GPUSimpleVern9
+    GPUSimpleVern9()
 
-GPU-compatible Verner 9th order Runge-Kutta method with fixed time step.
+Construct a GPU-compatible fixed-step Verner ninth-order algorithm.
 
-This is a 9th order explicit Runge-Kutta method designed for GPU compatibility.
-It only supports out-of-place formulations and provides extremely high accuracy
-for very smooth problems where tight error tolerances are required.
+`GPUSimpleVern9` is an out-of-place Verner 9/8 explicit Runge-Kutta
+implementation intended for GPU kernels and static-array workloads.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time keywords such as `dt`,
+`saveat`, and `save_everystep` to `solve`.
+
+# Returns
+
+A `GPUSimpleVern9` algorithm object for use with out-of-place
+`ODEProblem` definitions.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE (out-of-place only)
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
@@ -28,21 +40,14 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, GPUSimpleVern9(), dt = 0.1)
 ```
 
-## Parameters
+# Notes
 
-- `dt`: Fixed time step size (default: 0.1)
-- `saveat`: Optional times to save solution at
-- `save_everystep`: Save at every step (default: true)
+The default step size is `dt = 0.1f0`. In-place problem functions are not
+supported.
 
-## Restrictions
+# See Also
 
-- Out-of-place formulations only
-- Optimized for GPU execution
-
-## See also
-
-- [`GPUSimpleAVern9`](@ref) for the adaptive step size version
-- [`GPUSimpleVern7`](@ref) for a lower order but more efficient alternative
+[`GPUSimpleAVern9`](@ref), [`GPUSimpleVern7`](@ref)
 """
 struct GPUSimpleVern9 <: AbstractSimpleDiffEqODEAlgorithm end
 export GPUSimpleVern9
@@ -354,20 +359,32 @@ end
 #######################################################################################
 
 """
-    GPUSimpleAVern9
+    GPUSimpleAVern9()
 
-GPU-compatible adaptive Verner 9th order Runge-Kutta method.
+Construct a GPU-compatible adaptive Verner ninth-order algorithm.
 
-This is a GPU-optimized adaptive version of the Verner 9th order method with PI-controlled
-adaptive stepping. It only supports out-of-place formulations and provides extremely high
-accuracy with automatic step size control for very smooth problems.
+`GPUSimpleAVern9` is an out-of-place adaptive Verner 9/8 explicit Runge-Kutta
+implementation intended for GPU kernels and static-array workloads.
 
-## Example
+# Arguments
+
+No positional arguments are accepted.
+
+# Keywords
+
+No constructor keywords are accepted. Pass solve-time keywords such as `dt`,
+`abstol`, `reltol`, `saveat`, and `save_everystep` to `solve`.
+
+# Returns
+
+A `GPUSimpleAVern9` algorithm object for use with out-of-place
+`ODEProblem` definitions.
+
+# Example
 
 ```julia
 using SimpleDiffEq
 
-# Define ODE (out-of-place only)
 f(u, p, t) = 1.01 * u
 
 u0 = 0.5
@@ -377,23 +394,14 @@ prob = ODEProblem(f, u0, tspan)
 sol = solve(prob, GPUSimpleAVern9(), dt = 0.1, abstol = 1e-9, reltol = 1e-6)
 ```
 
-## Parameters
+# Notes
 
-- `dt`: Initial time step size (default: 0.1)
-- `abstol`: Absolute tolerance (default: 1e-6)
-- `reltol`: Relative tolerance (default: 1e-3)
-- `saveat`: Optional times to save solution at
-- `save_everystep`: Save at every step (default: true)
+The default initial step is `dt = 0.1f0`, with `abstol = 1f-6` and
+`reltol = 1f-3`. In-place problem functions are not supported.
 
-## Restrictions
+# See Also
 
-- Out-of-place formulations only
-- Optimized for GPU execution
-
-## See also
-
-- [`GPUSimpleVern9`](@ref) for the fixed step size version
-- [`GPUSimpleAVern7`](@ref) for a lower order adaptive alternative
+[`GPUSimpleVern9`](@ref), [`GPUSimpleAVern7`](@ref)
 """
 struct GPUSimpleAVern9 end
 export GPUSimpleAVern9

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,124 @@
 using SciMLTesting, SimpleDiffEq, Test
 using JET
 
+function source_public_marked_names()
+    marked_names = Symbol[]
+    srcdir = normpath(joinpath(@__DIR__, "..", "..", "src"))
+
+    for (root, _, files) in walkdir(srcdir), file in files
+        endswith(file, ".jl") || continue
+
+        for line in eachline(joinpath(root, file))
+            stripped = strip(replace(line, r"#.*$" => ""))
+
+            if startswith(stripped, "public ")
+                for item in split(stripped[(lastindex("public ") + 1):end], ',')
+                    m = match(r"^([A-Za-z_@][A-Za-z_0-9!]*)", strip(item))
+                    m === nothing || push!(marked_names, Symbol(m.captures[1]))
+                end
+            end
+
+            for m in eachmatch(r"(?:\bSciMLPublic\.)?@public\s+([A-Za-z_@][A-Za-z_0-9!]*)", stripped)
+                push!(marked_names, Symbol(m.captures[1]))
+            end
+        end
+    end
+
+    return unique(marked_names)
+end
+
+function public_api_names(mod::Module)
+    public_names = Symbol[]
+
+    for name in names(mod; all = false, imported = true)
+        name === nameof(mod) && continue
+
+        if Base.isexported(mod, name) ||
+                (isdefined(Base, :ispublic) && Base.ispublic(mod, name))
+            push!(public_names, name)
+        end
+    end
+
+    append!(public_names, source_public_marked_names())
+    return sort!(unique(public_names); by = string)
+end
+
+function has_docstring(mod::Module, name::Symbol)
+    doc = Base.Docs.doc(Base.Docs.Binding(mod, name))
+    doc === nothing && return false
+
+    text = sprint(show, MIME("text/plain"), doc)
+    return !isempty(strip(text)) && !occursin("No documentation found", text)
+end
+
+function source_module_for(mod::Module, name::Symbol)
+    value = getfield(mod, name)
+    return value isa Module ? value : parentmodule(value)
+end
+
+function docs_entry_name(line)
+    stripped = strip(line)
+    isempty(stripped) && return nothing
+
+    stripped = replace(stripped, r"\s+#.*$" => "")
+    startswith(stripped, "SimpleDiffEq.") &&
+        (stripped = stripped[(lastindex("SimpleDiffEq.") + 1):end])
+
+    return Symbol(stripped)
+end
+
+function documented_api_names()
+    documented_names = Symbol[]
+    docs_src = normpath(joinpath(@__DIR__, "..", "..", "docs", "src"))
+
+    for (root, _, files) in walkdir(docs_src), file in files
+        endswith(file, ".md") || continue
+
+        in_docs_block = false
+        in_reexport_block = false
+        for line in eachline(joinpath(root, file))
+            stripped = strip(line)
+
+            if startswith(stripped, "```@docs")
+                in_docs_block = true
+                continue
+            elseif in_docs_block && startswith(stripped, "```")
+                in_docs_block = false
+                continue
+            elseif startswith(stripped, "<!-- public-api-reexports-start -->")
+                in_reexport_block = true
+                continue
+            elseif startswith(stripped, "<!-- public-api-reexports-end -->")
+                in_reexport_block = false
+                continue
+            elseif in_docs_block
+                name = docs_entry_name(stripped)
+                name === nothing || push!(documented_names, name)
+            elseif in_reexport_block
+                m = match(r"^-\s+`([^`]+)`", stripped)
+                m === nothing || push!(documented_names, Symbol(m.captures[1]))
+            end
+        end
+    end
+
+    return sort!(unique(documented_names); by = string)
+end
+
+@testset "public API documentation" begin
+    public_names = public_api_names(SimpleDiffEq)
+    documented_names = documented_api_names()
+
+    missing_docstrings = filter(public_names) do name
+        source_mod = source_module_for(SimpleDiffEq, name)
+        !(has_docstring(source_mod, name) || has_docstring(SimpleDiffEq, name))
+    end
+
+    missing_docs_entries = setdiff(public_names, documented_names)
+
+    @test isempty(missing_docstrings)
+    @test isempty(missing_docs_entries)
+end
+
 run_qa(
     SimpleDiffEq;
     explicit_imports = true,


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Adds source-site docstrings for the SimpleDiffEq-owned exported solver constructors using a consistent arguments/keywords/returns/examples structure.
- Adds Documenter docs covering the owned API with `@docs`, a canonical `u_modified!` compatibility hook entry, and a rendered list of reexported SciML interface names.
- Adds QA coverage that checks exported/public names and source `public`/`@public` markings have docstrings and docs entries.
- Adds `GPUSimpleEuler` to the README algorithm table and ignores generated `docs/build/` output.

## Validation

- `timeout 3600 ~/.juliaup/bin/julia +1.10 -e 'using Runic; exit(Runic.main(ARGS))' -- --check docs/make.jl test/qa/qa.jl src/SimpleDiffEq.jl src/functionmap.jl src/euler_maruyama.jl src/euler/euler.jl src/euler/gpueuler.jl src/euler/loopeuler.jl src/rk4/rk4.jl src/rk4/gpurk4.jl src/rk4/looprk4.jl src/tsit5/tsit5.jl src/tsit5/atsit5.jl src/tsit5/gpuatsit5.jl src/verner/gpuvern7.jl src/verner/gpuvern9.jl`
- `timeout 3600 ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
- `timeout 3600 ~/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path = pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'`
- `timeout 3600 ~/.juliaup/bin/julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path = pwd())); Pkg.instantiate(); include("docs/make.jl")'`