### PR TITLE
Release prep: bump SimpleDiffEq to 1.16.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimpleDiffEq"
 uuid = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
-version = "1.16.1"
+version = "1.16.2"
 repo = "https://github.com/SciML/SimpleDiffEq.jl.git"
 
 [deps]


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/docs changes since 1.16.1.