### PR TITLE
Remove QA self-source path

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,9 +8,6 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SimpleDiffEq = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SimpleDiffEq = { path = "../.." }
-
 [compat]
 Aqua = "0.8"
 DiffEqBase = "7"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- remove the redundant `SimpleDiffEq = { path = "../.." }` self-source from `test/qa/Project.toml`
- keep the existing SciMLTesting v2.1 public API docs QA setup through `run_qa(...; api_docs_kwargs = (; rendered = true))`

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic_env -e 'using Runic; file = "test/qa/qa.jl"; original = read(file, String); formatted = Runic.format_string(original; filemode = true); if original == formatted; println("Runic check passed for ", file); else; println("Runic check failed for ", file); exit(1); end'`
- `timeout 3600 env GROUP=QA JULIA_PKG_PRECOMPILE_AUTO=0 /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'`
- `find test -path '*/[qQ][aA]/Project.toml' ...` source scan: no `[sources]` tables or `path =` entries found in QA Project.toml files.