### PR TITLE
Release prep: bump version to 1.16.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SimpleDiffEq"
 uuid = "05bca326-078c-5bf0-a5bf-ce7c7982d7fd"
-version = "1.16.2"
+version = "1.16.3"
 repo = "https://github.com/SciML/SimpleDiffEq.jl.git"
 
 [deps]


### PR DESCRIPTION
## Summary

Bumps the package version from 1.16.2 to 1.16.3 to register the one unreleased commit sitting on top of the last release.

The last registered version (1.16.2) corresponds to commit 1d7279a ("Bump SimpleDiffEq to 1.16.2 for release (#128)") — its root tree hash (`a805858ff9299c81d3595daf9eba938fa661cfb4`) matches the `git-tree-sha1` recorded for 1.16.2 in the General registry's `Versions.toml`.

Since that commit, the only change on `master` is:

- `d08fbf6` "Remove QA self-source path (#129)" — removes a `[sources]` override (`SimpleDiffEq = { path = "../.." }`) from `test/qa/Project.toml`. This only affects the internal QA test project's dependency resolution and does not touch any shipped source file, exported API, or the package's own `[compat]` bounds.

## Bump type

**PATCH** (1.16.2 → 1.16.3). The only change is to test/QA tooling configuration — no source code, no public API, and no functional changes. No new features or breaking changes were introduced, so PATCH is appropriate.

## Compat bounds

Not touched. The change doesn't add or alter any dependency usage or `[compat]` entries in the package's `Project.toml`; the modified file (`test/qa/Project.toml`) is a QA-only auxiliary project unrelated to the package's own compat bounds.