### PR TITLE
docs: remove redundant warnonly default

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,5 @@ makedocs(;
     pages = [
         "Home" => "index.md",
     ],
-    checkdocs = :exports,
-    warnonly = false
+    checkdocs = :exports
 )


### PR DESCRIPTION
## What changed
Remove the explicit `warnonly = false` from `docs/make.jl`. Documenter already uses strict warning handling by default, so this repository-specific override adds no behavior.

## Verification
- Audited current default branch at commit 14354ed6a0e00cd190a58cd75faf495ebfc71470.
- `julia --project=docs docs/make.jl` passed before and after; `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'` passed with QA/qa.jl 21/21 and QA/jet_type_stability_tests.jl 8/8.
- `julia -e 'using Runic; ...'` confirmed the edited file is already formatted; `git diff --check` and `typos --diff` passed.

Please ignore this draft until reviewed by @ChrisRackauckas.