### PR TITLE
Restore documented SciML common interface reexports

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ makedocs(;
     ),
     pages = [
         "Home" => "index.md",
+        "Reexported interface" => "reexports.md",
     ],
     checkdocs = :exports
 )

--- a/docs/src/reexports.md
+++ b/docs/src/reexports.md
@@ -1,0 +1,11 @@
+# Reexported SciML common interface
+
+`using SimpleDiffEq` also brings in the parts of the SciML common interface used to
+construct and solve the problems supported by this package. These names are owned and
+documented by [SciMLBase](https://docs.sciml.ai/SciMLBase/stable/):
+
+  - Problems: `ODEProblem`, `SDEProblem`, and `DiscreteProblem`
+  - Solving: `solve`, `init`, and `step!`
+  - Integrator interface: `reinit!`
+
+Anything else from SciMLBase must be imported from SciMLBase directly.

--- a/src/SimpleDiffEq.jl
+++ b/src/SimpleDiffEq.jl
@@ -4,15 +4,17 @@ module SimpleDiffEq
 
     using MuladdMacro: @muladd
     using FastBroadcast: @..
-    using DiffEqBase: DiffEqBase, ODEProblem, SDEProblem, DiscreteProblem,
-        isinplace, reinit!, step!
-    using SciMLBase: SciMLBase, AbstractODEAlgorithm
+    using DiffEqBase: DiffEqBase, isinplace
+    using SciMLBase: SciMLBase, AbstractODEAlgorithm, DiscreteProblem, ODEProblem,
+        SDEProblem, init, reinit!, solve, step!
     import SciMLBase: allows_arbitrary_number_types, allowscomplex, isautodifferentiable, isadaptive
     using StaticArrays: SArray, SVector, MVector
     using RecursiveArrayTools: recursivecopy!
     using LinearAlgebra: mul!
     using Parameters: @unpack
     using PrecompileTools: @compile_workload, @setup_workload
+
+    export DiscreteProblem, ODEProblem, SDEProblem, init, reinit!, solve, step!
 
     @inline _copy(a::SArray) = a
     @inline _copy(a) = copy(a)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,14 @@
 using SciMLTesting, SimpleDiffEq, Test
 
-run_qa(SimpleDiffEq)
+const REEXPORTS = (
+    :DiscreteProblem, :ODEProblem, :SDEProblem, :init, :reinit!, :solve, :step!,
+)
+
+run_qa(SimpleDiffEq; reexports_allow = REEXPORTS)
+
+@testset "Reexport surface" begin
+    @testset "$name" for name in REEXPORTS
+        @test name in names(SimpleDiffEq)
+        @test isdefined(@__MODULE__, name)
+    end
+end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## What changed and why

The strict-QA cleanup removed SimpleDiffEq's upstream API facade, but it also made the README's documented `using SimpleDiffEq` workflow fail because `ODEProblem`, `solve`, and `init` disappeared. This restores only the common interface used to construct and solve the three problem classes supported by SimpleDiffEq: `ODEProblem`, `SDEProblem`, `DiscreteProblem`, `solve`, `init`, `step!`, and `reinit!`.

The same seven-name list is explicit in the owner imports/export block and the strict-QA `REEXPORTS` tuple. A rendered documentation page groups the names by role, links SciMLBase, and tells users to import every other SciMLBase name directly.

## Verification

Failing before the fix (Julia 1.12.4):

```text
$ julia +1.12.4 --project=. -e 'using SimpleDiffEq; expected=(:DiscreteProblem, :ODEProblem, :SDEProblem, :init, :reinit!, :solve, :step!); missing=setdiff(expected,names(SimpleDiffEq)); @assert isempty(missing) "missing reexports: $(join(missing, ", "))"'
ERROR: AssertionError: missing reexports: DiscreteProblem, ODEProblem, SDEProblem, init, reinit!, solve, step!
```

Passing with the fix:

```text
$ GROUP=QA julia +1.12.4 --project=. -e 'using Pkg; Pkg.test()'
QA/jet_type_stability_tests.jl | 8/8
QA/qa.jl                      | 35/35
Testing SimpleDiffEq tests passed

$ GROUP=Core julia +1.12.4 --project=. -e 'using Pkg; Pkg.test()'
Core/alloc_tests.jl               | 8/8
Core/discrete_tests.jl            | 14 pass, 1 pre-existing broken
Core/gpu_ode_regression.jl        | 48/48
Core/gpusimpleatsit5_tests.jl     | 16/16
Core/interface_tests.jl           | 23/23
Core/precompile_workload_tests.jl | 3/3
Core/simpleatsit5_tests.jl        | 44/44
Core/simpleem_tests.jl            | 8/8
Core/simpleeuler_tests.jl         | 6/6
Core/simplerk4_tests.jl           | 6/6
Core/simpletsit5_tests.jl         | 3/3
Testing SimpleDiffEq tests passed

$ julia +1.12.4 --project=docs docs/make.jl
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="1.17.0"` for inventory from ../Project.toml

$ julia +1.12.4 -m Runic --check docs/make.jl src/SimpleDiffEq.jl test/qa/qa.jl
# exit 0

$ typos docs/make.jl docs/src/reexports.md src/SimpleDiffEq.jl test/qa/qa.jl
# exit 0
```

The existing SciMLBase compat floor is 3.27.0. All seven explicit imports are exported at that tag, so this change does not raise the floor.

## Not verified

- Julia LTS and prerelease lanes were not run locally.
- Downstream packages were not run locally.

## For the reviewer

The judgment call is the narrow interface boundary. Solver-author types and hooks from the former facade remain excluded because they are not part of ordinary documented use.

AI agent: OpenAI Codex, session `01a03a11-47c2-77e0-858b-167004f0b79c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
