### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,71 @@
+using SimpleDiffEq, BenchmarkTools
+using LinearAlgebra, StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+# Lotka-Volterra
+function lotka!(du, u, p, t)
+    du[1] = 1.5u[1] - u[1] * u[2]
+    du[2] = u[1] * u[2] - 3.0u[2]
+    return nothing
+end
+lotka_prob = ODEProblem(lotka!, [1.0, 1.0], (0.0, 10.0))
+
+# Slightly larger system (linear, skew-symmetric → bounded)
+const N = 30
+A = randn(rng, N, N)
+A = A - A'
+u0_N = randn(rng, N)
+function lin!(du, u, p, t)
+    mul!(du, p, u)
+    return nothing
+end
+lin_prob = ODEProblem(lin!, u0_N, (0.0, 1.0), A)
+
+# Scalar ODE (out-of-place path)
+scalar_prob = ODEProblem((u, p, t) -> -u + sin(t), 1.0, (0.0, 10.0))
+
+# =============================================================================
+# Fixed-step explicit solvers
+# =============================================================================
+
+SUITE["fixed_step"] = BenchmarkGroup()
+
+SUITE["fixed_step"]["SimpleRK4_small"] = @benchmarkable solve(
+    $lotka_prob, SimpleRK4(); dt = 0.01
+)
+SUITE["fixed_step"]["SimpleTsit5_small"] = @benchmarkable solve(
+    $lotka_prob, SimpleTsit5(); dt = 0.01
+)
+SUITE["fixed_step"]["SimpleRK4_medium"] = @benchmarkable solve(
+    $lin_prob, SimpleRK4(); dt = 0.001
+)
+SUITE["fixed_step"]["SimpleTsit5_medium"] = @benchmarkable solve(
+    $lin_prob, SimpleTsit5(); dt = 0.001
+)
+
+# =============================================================================
+# Adaptive solver
+# =============================================================================
+
+SUITE["adaptive"] = BenchmarkGroup()
+
+SUITE["adaptive"]["SimpleATsit5_scalar"] = @benchmarkable solve(
+    $scalar_prob, SimpleATsit5()
+)
+SUITE["adaptive"]["SimpleATsit5_small"] = @benchmarkable solve(
+    $lotka_prob, SimpleATsit5()
+)
+
+# =============================================================================
+# Discrete map
+# =============================================================================
+
+SUITE["discrete"] = BenchmarkGroup()
+
+logistic(u, p, t) = p * u * (1 - u)
+map_prob = DiscreteProblem(logistic, 0.5, (0, 1000), 3.7)
+SUITE["discrete"]["SimpleFunctionMap"] = @benchmarkable solve(
+    $map_prob, SimpleFunctionMap()
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~26s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~26s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md