### PR TITLE
Allow JET 0.12 in the QA test environment

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,7 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 DiffEqBase = "7"
-JET = "0.9, 0.10, 0.11"
+JET = "0.9, 0.10, 0.11, 0.12"
 SafeTestsets = "0.1"
 SciMLBase = "3.27"
 SciMLTesting = "2.4"


### PR DESCRIPTION
## Summary

- `test/qa/Project.toml` capped `JET = "0.9, 0.10, 0.11"`, so the QA job resolves JET 0.11.6 on the `julia '1'` lane (now Julia 1.13.0).
- JET 0.11.x on Julia 1.13 reports false-positive `runtime dispatch` findings for fully-concrete `Base.Broadcast`/`materialize!` code paths — this is JET.jl#839, fixed upstream in JET 0.12.
- Result: `jet_type_stability_tests.jl` fails on master for SimpleEuler, SimpleRK4, SimpleTsit5, and SimpleATsit5 even though `code_typed` shows every flagged frame compiles concrete.
- Adding `0.12` to the compat lets the resolver pick JET 0.12.1 on Julia 1.13. JET ≥ 0.11.4 requires `julia = "1.12"`, so the LTS lane is unaffected (it keeps resolving JET ≤ 0.9.x as before).

## Verification

Local, Julia 1.13.0, JET 0.12.1:
- `test/qa/qa.jl`: 20/20 pass (previously failed under JET 0.11.6)
- `test/qa/jet_type_stability_tests.jl`: 8/8 pass (previously 5 failures)

🤖 Generated with [Devin](https://devin.ai) CLI 3000.10.21 (model: SWE-2 Max)
Session: local Devin CLI session (`/home/crackauc/.local/share/devin/cli/sessions.db`)